### PR TITLE
Correct small edge case in rotation option

### DIFF
--- a/RCTCameraManager.m
+++ b/RCTCameraManager.m
@@ -347,6 +347,10 @@ RCT_EXPORT_METHOD(stopCapture) {
       else {
         callback(@[RCTMakeError(error.description, nil, nil)]);
       }
+      CFRelease(imageDataSampleBuffer);
+      CGImageRelease(cgImage);
+      CFRelease(source);
+      CFRelease(destination);
     }];
   }
 }

--- a/RCTCameraManager.m
+++ b/RCTCameraManager.m
@@ -308,8 +308,8 @@ RCT_EXPORT_METHOD(stopCapture) {
       CGImageRef cgImage;
       cgImage = CGImageSourceCreateImageAtIndex(source, 0, NULL);
 
-      float rotation = [[options objectForKey:@"rotation"] floatValue];
-      if (rotation) {
+      if ([options objectForKey:@"rotation"]) {
+        float rotation = [[options objectForKey:@"rotation"] floatValue];
         cgImage = [self CGImageRotatedByAngle:cgImage angle:rotation];
       } else {
         // Get metadata orientation


### PR DESCRIPTION
Didn't realize that objc coerces 0 to false.