### PR TITLE
In RCTCameraManager.m, encapsulated many of the "dispatch_async" bloc…

### DIFF
--- a/Camera.ios.js
+++ b/Camera.ios.js
@@ -82,10 +82,12 @@ var Camera = React.createClass({
   },
 
   componentWillMount() {
-    NativeModules.CameraManager.checkDeviceAuthorizationStatus((function(err, isAuthorized) {
-      this.state.isAuthorized = isAuthorized;
-      this.setState(this.state);
-    }).bind(this));
+    NativeModules.CameraManager.checkDeviceAuthorizationStatus((err, isAuthorized) => {
+      this.setState({
+        isAuthorized: isAuthorized
+      });
+    });
+
     this.cameraBarCodeReadListener = DeviceEventEmitter.addListener('CameraBarCodeRead', this._onBarCodeRead);
   },
 


### PR DESCRIPTION
In RCTCameraManager.m, I encapsulated many of the "dispatch_async" blocks within another dispatch_async block, along with setting the dispatch queue priority to high.

Made a minor tweak within Camera.ios.js -- wondering if there is a difference with this change over the previous version.

Personally I noticed that the number of "15-second UI locks" significantly reduced from EVERY time Camera is rendered vs. 1 out of every 4 times.  I am running React Native 0.7.1 on Iphone 5s, IOS 7.13