### PR TITLE
Tap-to-focus and Pinch-to-zoom

### DIFF
--- a/Camera.ios.js
+++ b/Camera.ios.js
@@ -51,7 +51,10 @@ var Camera = React.createClass({
     torchMode: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number
-    ])
+    ]),
+    defaultTouchToFocus: PropTypes.bool,
+    onFocusChanged: PropTypes.func,
+    onZoomChanged: PropTypes.func
   },
 
   mixins: [NativeMethodsMixin],
@@ -205,7 +208,10 @@ var RCTCamera = createReactNativeComponentClass({
     type: true,
     orientation: true,
     flashMode: true,
-    torchMode: true
+    torchMode: true,
+    onFocusChanged: true,
+    onZoomChanged: true,
+    defaultTouchToFocus: true
   }),
   uiViewClassName: 'RCTCamera',
 });

--- a/Camera.ios.js
+++ b/Camera.ios.js
@@ -52,7 +52,7 @@ var Camera = React.createClass({
       PropTypes.string,
       PropTypes.number
     ]),
-    defaultTouchToFocus: PropTypes.bool,
+    defaultOnFocusComponent: PropTypes.bool,
     onFocusChanged: PropTypes.func,
     onZoomChanged: PropTypes.func
   },
@@ -211,7 +211,7 @@ var RCTCamera = createReactNativeComponentClass({
     torchMode: true,
     onFocusChanged: true,
     onZoomChanged: true,
-    defaultTouchToFocus: true
+    defaultOnFocusComponent: true
   }),
   uiViewClassName: 'RCTCamera',
 });

--- a/CameraFocusSquare.h
+++ b/CameraFocusSquare.h
@@ -1,0 +1,3 @@
+#import <UIKit/UIKit.h>
+@interface RCTCameraFocusSquare : UIView
+@end

--- a/CameraFocusSquare.m
+++ b/CameraFocusSquare.m
@@ -1,0 +1,28 @@
+#import "CameraFocusSquare.h"
+#import <QuartzCore/QuartzCore.h>
+
+const float squareLength = 80.0f;
+@implementation RCTCameraFocusSquare
+
+- (id)initWithFrame:(CGRect)frame 
+{
+    self = [super initWithFrame:frame];
+    if (self) {
+        // Initialization code
+
+        [self setBackgroundColor:[UIColor clearColor]];
+        [self.layer setBorderWidth:2.0];
+        [self.layer setCornerRadius:4.0];
+        [self.layer setBorderColor:[UIColor whiteColor].CGColor];
+
+        CABasicAnimation* selectionAnimation = [CABasicAnimation
+                                                animationWithKeyPath:@"borderColor"];
+        selectionAnimation.toValue = (id)[UIColor blueColor].CGColor;
+        selectionAnimation.repeatCount = 8;
+        [self.layer addAnimation:selectionAnimation
+                          forKey:@"selectionAnimation"];
+
+    }
+    return self;
+}
+@end

--- a/RCTCamera.h
+++ b/RCTCamera.h
@@ -7,9 +7,9 @@
 @interface RCTCamera : UIView
 
 @property (nonatomic) RCTCameraManager *manager;
+@property (nonatomic) RCTBridge *bridge;
 @property (nonatomic) RCTCameraFocusSquare *camFocus;
-@property (nonatomic) BOOL multipleTouches;
 
-- (id)initWithManager:(RCTCameraManager*)manager;
+- (id)initWithManager:(RCTCameraManager*)manager bridge:(RCTBridge *)bridge;
 
 @end

--- a/RCTCamera.h
+++ b/RCTCamera.h
@@ -1,11 +1,14 @@
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
+#import "CameraFocusSquare.h"
 
 @class RCTCameraManager;
 
 @interface RCTCamera : UIView
 
 @property (nonatomic) RCTCameraManager *manager;
+@property (nonatomic) RCTCameraFocusSquare *camFocus;
+@property (nonatomic) BOOL multipleTouches;
 
 - (id)initWithManager:(RCTCameraManager*)manager;
 

--- a/RCTCamera.m
+++ b/RCTCamera.m
@@ -14,7 +14,7 @@
 {
   BOOL _multipleTouches;
   BOOL _onFocusChanged;
-  BOOL _defaultTouchToFocus;
+  BOOL _defaultOnFocusComponent;
   BOOL _onZoomChanged;
 }
 
@@ -76,18 +76,18 @@
   }
 }
 
-- (void)setDefaultTouchToFocus:(BOOL)enabled
+- (void)setDefaultOnFocusComponent:(BOOL)enabled
 {
-    if (_defaultTouchToFocus != enabled) {
-        _defaultTouchToFocus = enabled;
-    }
+  if (_defaultOnFocusComponent != enabled) {
+    _defaultOnFocusComponent = enabled;
+  }
 }
 
 - (void)setOnZoomChanged:(BOOL)enabled
 {
-    if (_onZoomChanged != enabled) {
-        _onZoomChanged = enabled;
-    }
+  if (_onZoomChanged != enabled) {
+    _onZoomChanged = enabled;
+  }
 }
 
 - (id)initWithManager:(RCTCameraManager*)manager bridge:(RCTBridge *)bridge
@@ -102,7 +102,7 @@
     [self.manager startSession];
     _multipleTouches = NO;
     _onFocusChanged = NO;
-    _defaultTouchToFocus = YES;
+    _defaultOnFocusComponent = YES;
     _onZoomChanged = NO;
   }
   return self;
@@ -177,7 +177,7 @@
         [self.bridge.eventDispatcher sendInputEventWithName:@"focusChanged" body:event];
 
         // Show animated rectangle on the touched area
-        if (_defaultTouchToFocus) {
+        if (_defaultOnFocusComponent) {
             self.camFocus = [[RCTCameraFocusSquare alloc]initWithFrame:CGRectMake(touchPoint.x-40, touchPoint.y-40, 80, 80)];
             [self.camFocus setBackgroundColor:[UIColor clearColor]];
             [self addSubview:self.camFocus];

--- a/RCTCamera.xcodeproj/project.pbxproj
+++ b/RCTCamera.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0314E39D1B661A460092D183 /* CameraFocusSquare.m in Sources */ = {isa = PBXBuildFile; fileRef = 0314E39C1B661A460092D183 /* CameraFocusSquare.m */; };
 		4107014D1ACB732B00C6AA39 /* RCTCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = 410701481ACB732B00C6AA39 /* RCTCamera.m */; };
 		4107014E1ACB732B00C6AA39 /* RCTCameraManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 4107014A1ACB732B00C6AA39 /* RCTCameraManager.m */; };
 		454EBCF41B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m in Sources */ = {isa = PBXBuildFile; fileRef = 454EBCF31B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m */; };
@@ -25,6 +26,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0314E39B1B661A0C0092D183 /* CameraFocusSquare.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CameraFocusSquare.h; sourceTree = "<group>"; };
+		0314E39C1B661A460092D183 /* CameraFocusSquare.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CameraFocusSquare.m; sourceTree = "<group>"; };
 		4107012F1ACB723B00C6AA39 /* libRCTCamera.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTCamera.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		410701471ACB732B00C6AA39 /* RCTCamera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RCTCamera.h; sourceTree = "<group>"; };
 		410701481ACB732B00C6AA39 /* RCTCamera.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RCTCamera.m; sourceTree = "<group>"; };
@@ -47,6 +50,8 @@
 		410701241ACB719800C6AA39 = {
 			isa = PBXGroup;
 			children = (
+				0314E39C1B661A460092D183 /* CameraFocusSquare.m */,
+				0314E39B1B661A0C0092D183 /* CameraFocusSquare.h */,
 				454EBCF31B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m */,
 				410701471ACB732B00C6AA39 /* RCTCamera.h */,
 				410701481ACB732B00C6AA39 /* RCTCamera.m */,
@@ -119,6 +124,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0314E39D1B661A460092D183 /* CameraFocusSquare.m in Sources */,
 				454EBCF41B5082DC00AD0F86 /* NSMutableDictionary+ImageMetadata.m in Sources */,
 				4107014E1ACB732B00C6AA39 /* RCTCameraManager.m in Sources */,
 				4107014D1ACB732B00C6AA39 /* RCTCamera.m in Sources */,

--- a/RCTCameraManager.h
+++ b/RCTCameraManager.h
@@ -73,7 +73,7 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 - (void)startSession;
 - (void)stopSession;
 - (void)focusAtThePoint:(CGPoint) atPoint;
-- (void)zoom:(CGFloat)velocity;
+- (void)zoom:(CGFloat)velocity reactTag:(NSNumber *)reactTag;
 
 
 @end

--- a/RCTCameraManager.h
+++ b/RCTCameraManager.h
@@ -60,6 +60,7 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 @property (nonatomic) NSInteger videoTarget;
 @property (nonatomic, strong) RCTResponseSenderBlock videoCallback;
 
+
 - (void)changeAspect:(NSString *)aspect;
 - (void)changeCamera:(NSInteger)camera;
 - (void)changeOrientation:(NSInteger)orientation;
@@ -71,5 +72,8 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 - (void)stopCapture;
 - (void)startSession;
 - (void)stopSession;
+- (void)focusAtThePoint:(CGPoint) atPoint;
+- (void)zoom:(CGFloat)velocity;
+
 
 @end

--- a/RCTCameraManager.m
+++ b/RCTCameraManager.m
@@ -93,16 +93,16 @@ RCT_EXPORT_VIEW_PROPERTY(torchMode, NSInteger);
   ];
 }
 
-RCT_EXPORT_VIEW_PROPERTY(defaultTouchToFocus, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(defaultOnFocusComponent, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(onFocusChanged, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(onZoomChanged, BOOL)
 
-- (NSDictionary *)customDirectEventTypes
+- (NSArray *)customDirectEventTypes
 {
-    return @{
-      @"focusChanged": @{ @"registrationName": @"onFocusChanged" },
-      @"zoomChanged":  @{ @"registrationName": @"onZoomChanged" },
-    };
+    return @[
+      @"focusChanged",
+      @"zoomChanged",
+    ];
 }
 
 - (id)init {

--- a/README.md
+++ b/README.md
@@ -186,6 +186,36 @@ Values:
 
 Use the `torchMode` property to specify the camera torch mode.
 
+#### `onFocusChanged`
+
+Args:
+```
+e: {
+  nativeEvent: {
+    touchPoint: { x, y }
+  }
+}
+```
+Will call when touch to focus has been made.
+
+#### `defaultOnFocusComponent`
+
+Values:
+`true` (default)
+`false`
+
+#### `onFocusChanged`
+
+Args:
+```
+  e: {
+    nativeEvent: {
+      velocity, zoomFactor
+    }
+  }
+```
+Will call when focus has changed.
+
 ## Component methods
 
 You can access component methods by adding a `ref` (ie. `ref="camera"`) prop to your `<Camera>` element, then you can use `this.refs.camera.capture(cb)`, etc. inside your component.

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The type of capture that will be performed by the camera - either a still image 
 
 #### `captureTarget`
 
-Values: `Camera.constants.CaptureTarget.cameraRoll` (default), `Camera.constants.CaptureTarget.disk`, ~~`Camera.constants.CaptureTarget.memory`~~ (deprecated), 
+Values: `Camera.constants.CaptureTarget.cameraRoll` (default), `Camera.constants.CaptureTarget.disk`, ~~`Camera.constants.CaptureTarget.memory`~~ (deprecated),
 
 This property allows you to specify the target output of the captured image data. By default the image binary is sent back as a base 64 encoded string. The disk output has been shown to improve capture response time, so that is the recommended value.
 
@@ -197,6 +197,7 @@ e: {
 }
 ```
 Will call when touch to focus has been made.
+By default, `onFocusChanged` is not defined and tap-to-focus is disabled.
 
 #### `defaultOnFocusComponent`
 
@@ -204,7 +205,9 @@ Values:
 `true` (default)
 `false`
 
-#### `onFocusChanged`
+If `defaultOnFocusComponent` set to false, default internal implementation of visual feedback for tap-to-focus gesture will be disabled.
+
+#### `onZoomChanged`
 
 Args:
 ```
@@ -215,6 +218,7 @@ Args:
   }
 ```
 Will call when focus has changed.
+By default, `onZoomChanged` is not defined and pinch-to-zoom is disabled.
 
 ## Component methods
 
@@ -229,7 +233,7 @@ Supported options:
  - `audio` (See `captureAudio` under Properties)
  - `mode` (See  `captureMode` under Properties)
  - `target` (See `captureTarget` under Properties)
- 
+
 #### `stopCapture()`
 
 Ends the current capture session for video captures. Only applies when the current `captureMode` is `video`.


### PR DESCRIPTION
I'm making an app which heavily use `react-native-camera` awesome module. And I'd like to make some contributions. This is initial approach to add two features: Tap to focus and Pinch to zoom. For now, it isn't customizable and I would be happy if you look at this, review and we could discuss some API changes and that should be configurable.
1. For now a small rechtangle has a fixed width (80px) and fixed animation (1 second blinking) and implemented totally on the native side. I think it should be up to user, so `<Camera focusedComponent={myComponent} />`? Or just `<Camera onFocusChanged={}`?
2. Focusing functionality is also has customizable constants. Maybe I should reuse `focusWithMode()` but allow user to set focus zone. 
3. Zoom could be calibrated with some constants too, I don't know if this fits for everybody or needs to be customized too. 
4. Should these features be enabled by default, but not always enabled? `<Camera tapToFocus={false} pinchToZoom={false}/>`?