### PR TITLE
Use proper check to see if running on simulator

### DIFF
--- a/RCTCameraManager.m
+++ b/RCTCameraManager.m
@@ -213,13 +213,11 @@ RCT_EXPORT_METHOD(stopCapture) {
   }
 }
 
-- (BOOL)isSimulator {
-  return [[[UIDevice currentDevice].model lowercaseString] rangeOfString:@"simulator"].location != NSNotFound;
-}
-
 - (void)startSession {
-  if ([self isSimulator]) return;
-  
+#if TARGET_IPHONE_SIMULATOR
+  return;
+#endif
+	
   dispatch_async(self.sessionQueue, ^{
     if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
       self.presetCamera = AVCaptureDevicePositionBack;
@@ -262,8 +260,10 @@ RCT_EXPORT_METHOD(stopCapture) {
 }
 
 - (void)stopSession {
-  if ([self isSimulator]) return;
-  
+#if TARGET_IPHONE_SIMULATOR
+  return;
+#endif
+	
   dispatch_async(self.sessionQueue, ^{
     [self.previewLayer removeFromSuperlayer];
     [self.session stopRunning];
@@ -329,8 +329,7 @@ RCT_EXPORT_METHOD(stopCapture) {
 
 - (void)captureStill:(NSInteger)target options:(NSDictionary *)options callback:(RCTResponseSenderBlock)callback {
   dispatch_async(self.sessionQueue, ^{
-    if ([self isSimulator]){
-
+#if TARGET_IPHONE_SIMULATOR
       CGSize size = CGSizeMake(720, 1280);
       UIGraphicsBeginImageContextWithOptions(size, YES, 0);
         [[UIColor whiteColor] setFill];
@@ -340,9 +339,7 @@ RCT_EXPORT_METHOD(stopCapture) {
 
       NSData *imageData = UIImageJPEGRepresentation(image, 1.0);
       [self saveImage:imageData target:target metadata:nil callback:callback];
-
-    } else {
-
+#else
       [[self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo] setVideoOrientation:self.previewLayer.connection.videoOrientation];
 
       [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:[self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo] completionHandler:^(CMSampleBufferRef imageDataSampleBuffer, NSError *error) {
@@ -406,7 +403,7 @@ RCT_EXPORT_METHOD(stopCapture) {
           callback(@[RCTMakeError(error.description, nil, nil)]);
         }
       }];
-    }
+#endif
   });
 }
 


### PR DESCRIPTION
# What
Fixes a busted `isSimulator` check in Xcode 7. Without this fix `isSimulator` will always return `NO` when running in Xcode 7. As a consequence the project will crash with the message `AVCaptureSession can't startRunning between calls to beginConfiguration / commitConfiguration`.

@lwansbrough