### PR TITLE
move beginConfiguration down to prevent not commiting

### DIFF
--- a/Camera.ios.js
+++ b/Camera.ios.js
@@ -77,9 +77,9 @@ var Camera = React.createClass({
   getInitialState() {
     return {
       isAuthorized: false,
-      isRecording: false
     };
   },
+  isRecording: false,
 
   componentWillMount() {
     NativeModules.CameraManager.checkDeviceAuthorizationStatus((function(err, isAuthorized) {
@@ -91,9 +91,9 @@ var Camera = React.createClass({
 
   componentWillUnmount() {
     this.cameraBarCodeReadListener.remove();
-    
-    if (this.state.isRecording) {
-      this.stopRecording();
+
+    if (this.isRecording) {
+      this.stopCapture();
     }
   },
 
@@ -127,7 +127,7 @@ var Camera = React.createClass({
     if (typeof aspect === 'string') {
       aspect = constants.Aspect[aspect];
     }
-    
+
     if (typeof flashMode === 'string') {
       flashMode = constants.FlashMode[flashMode];
     }
@@ -135,7 +135,7 @@ var Camera = React.createClass({
     if (typeof orientation === 'string') {
       orientation = constants.Orientation[orientation];
     }
-    
+
     if (typeof torchMode === 'string') {
       torchMode = constants.TorchMode[torchMode];
     }
@@ -176,11 +176,11 @@ var Camera = React.createClass({
     if (typeof options.mode === 'string') {
       options.mode = constants.CaptureMode[options.mode];
     }
-    
+
     if (options.mode === constants.CaptureMode.video) {
       options.totalSeconds = (options.totalSeconds > -1 ? options.totalSeconds : -1);
       options.preferredTimeScale = options.preferredTimeScale || 30;
-      this.setState({ isRecording: true });
+      this.isRecording = true;
     }
 
     if (typeof options.target === 'string') {
@@ -191,9 +191,9 @@ var Camera = React.createClass({
   },
 
   stopCapture() {
-    if (this.state.isRecording) {
+    if (this.isRecording) {
       NativeModules.CameraManager.stopCapture();
-      this.setState({ isRecording: false });
+      this.isRecording = false;
     }
   }
 

--- a/RCTCameraManager.m
+++ b/RCTCameraManager.m
@@ -219,12 +219,12 @@ RCT_EXPORT_METHOD(stopCapture) {
 
 - (void)startSession {
   if ([self isSimulator]) return;
-  
+
   dispatch_async(self.sessionQueue, ^{
     if (self.presetCamera == AVCaptureDevicePositionUnspecified) {
       self.presetCamera = AVCaptureDevicePositionBack;
     }
-    
+
     AVCaptureStillImageOutput *stillImageOutput = [[AVCaptureStillImageOutput alloc] init];
     if ([self.session canAddOutput:stillImageOutput])
     {
@@ -232,14 +232,14 @@ RCT_EXPORT_METHOD(stopCapture) {
       [self.session addOutput:stillImageOutput];
       self.stillImageOutput = stillImageOutput;
     }
-    
+
     AVCaptureMovieFileOutput *movieFileOutput = [[AVCaptureMovieFileOutput alloc] init];
     if ([self.session canAddOutput:movieFileOutput])
     {
       [self.session addOutput:movieFileOutput];
       self.movieFileOutput = movieFileOutput;
     }
-    
+
     AVCaptureMetadataOutput *metadataOutput = [[AVCaptureMetadataOutput alloc] init];
     if ([self.session canAddOutput:metadataOutput]) {
       [metadataOutput setMetadataObjectsDelegate:self queue:self.sessionQueue];
@@ -247,7 +247,7 @@ RCT_EXPORT_METHOD(stopCapture) {
       [metadataOutput setMetadataObjectTypes:metadataOutput.availableMetadataObjectTypes];
       self.metadataOutput = metadataOutput;
     }
-    
+
     __weak RCTCameraManager *weakSelf = self;
     [self setRuntimeErrorHandlingObserver:[NSNotificationCenter.defaultCenter addObserverForName:AVCaptureSessionRuntimeErrorNotification object:self.session queue:nil usingBlock:^(NSNotification *note) {
       RCTCameraManager *strongSelf = weakSelf;
@@ -256,21 +256,21 @@ RCT_EXPORT_METHOD(stopCapture) {
         [strongSelf.session startRunning];
       });
     }]];
-    
+
     [self.session startRunning];
   });
 }
 
 - (void)stopSession {
   if ([self isSimulator]) return;
-  
+
   dispatch_async(self.sessionQueue, ^{
     [self.previewLayer removeFromSuperlayer];
     [self.session stopRunning];
     for(AVCaptureInput *input in self.session.inputs) {
       [self.session removeInput:input];
     }
-    
+
     for(AVCaptureOutput *output in self.session.outputs) {
       [self.session removeOutput:output];
     }
@@ -279,19 +279,17 @@ RCT_EXPORT_METHOD(stopCapture) {
 
 - (void)initializeCaptureSessionInput:(NSString *)type {
   dispatch_async(self.sessionQueue, ^{
-    
-    [self.session beginConfiguration];
-    
+
     NSError *error = nil;
     AVCaptureDevice *captureDevice;
-    
+
     if (type == AVMediaTypeAudio) {
       captureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
     }
     else if (type == AVMediaTypeVideo) {
       captureDevice = [self deviceWithMediaType:AVMediaTypeVideo preferringPosition:self.presetCamera];
     }
-    
+
     if (captureDevice == nil) {
       return;
     }
@@ -302,6 +300,8 @@ RCT_EXPORT_METHOD(stopCapture) {
       NSLog(@"%@", error);
       return;
     }
+
+    [self.session beginConfiguration];
 
     if (type == AVMediaTypeAudio) {
       [self.session removeInput:self.audioCaptureDeviceInput];

--- a/RCTCameraManager.m
+++ b/RCTCameraManager.m
@@ -98,7 +98,7 @@ RCT_EXPORT_VIEW_PROPERTY(torchMode, NSInteger);
   if ((self = [super init])) {
 
     self.session = [AVCaptureSession new];
-    self.session.sessionPreset = AVCaptureSessionPresetHigh;
+    self.session.sessionPreset = AVCaptureSessionPresetMedium;
 
     self.previewLayer = [AVCaptureVideoPreviewLayer layerWithSession:self.session];
     self.previewLayer.needsDisplayOnBoundsChange = YES;


### PR DESCRIPTION
Crash caused by beginConfiguration without commitConfiguration.  Move down the beginConfiguration to be after error checking to ensure we always call commit after begin.