### PR TITLE
(fix) stopRecording method is not defined, switched to stopCapture.

### DIFF
--- a/Camera.ios.js
+++ b/Camera.ios.js
@@ -84,7 +84,7 @@ var Camera = React.createClass({
     this.cameraBarCodeReadListener.remove();
     
     if (this.state.isRecording) {
-      this.stopRecording();
+      this.stopCapture();
     }
   },
 


### PR DESCRIPTION
This was causing an error when unmounting the component.