### PR TITLE
Set self.camera to nil when stopping session

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -284,6 +284,7 @@ RCT_EXPORT_METHOD(stopCapture) {
 #endif
 	
   dispatch_async(self.sessionQueue, ^{
+    self.camera = nil;
     [self.previewLayer removeFromSuperlayer];
     [self.session stopRunning];
     for(AVCaptureInput *input in self.session.inputs) {


### PR DESCRIPTION
This should fix the freeze problem with navigator (see [comment](https://github.com/lwansbrough/react-native-camera/issues/80#issuecomment-147336381) in #80), but I'm not sure if there are some side effects coming from this change. Yet in my app it seems to work.