### PR TITLE
Fix crash when user pinches to zoom on devices that don't support it.

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -709,6 +709,8 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
     AVCaptureDevice *device = [[self videoCaptureDeviceInput] device];
     if ([device lockForConfiguration:&error]) {
         CGFloat zoomFactor = device.videoZoomFactor + atan(velocity / pinchVelocityDividerFactor);
+        zoomFactor = zoomFactor >= 1 && zoomFactor <= device.activeFormat.videoMaxZoomFactor ? zoomFactor : 1.0f;
+
         NSDictionary *event = @{
                                 @"target": reactTag,
                                 @"zoomFactor": [NSNumber numberWithDouble:zoomFactor],
@@ -716,7 +718,7 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
                               };
         [self.bridge.eventDispatcher sendInputEventWithName:@"zoomChanged" body:event];
 
-        device.videoZoomFactor = zoomFactor >= 1.0f ? zoomFactor : 1.0f;
+        device.videoZoomFactor = zoomFactor;
         [device unlockForConfiguration];
     } else {
         NSLog(@"error: %@", error);


### PR DESCRIPTION
When zoomFactor was computed with a value greater than device.activeFormat.videoMaxZoomFactor, it caused a crash. Changed the pinch to zoom code to respect the value of device.activeFormat.videoMaxZoomFactor.

This fixes https://github.com/lwansbrough/react-native-camera/issues/107