### PR TITLE
Fix for back camera showing briefly when the type property is set to 'front'.

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -14,6 +14,12 @@
 
 RCT_EXPORT_MODULE();
 
+- (UIView *)viewWithProps:(__unused NSDictionary *)props
+{
+    self.presetCamera = ((NSNumber *)props[@"type"]).integerValue;
+    return [self view];
+}
+
 - (UIView *)view
 {
     return [[RCTCamera alloc] initWithManager:self bridge:self.bridge];


### PR DESCRIPTION
The first time an app is run that uses this component with the type set to 'front', the back camera shows briefly before the component obeys the type property and switches to the front camera. The presetCamera should be set to the camera type set in the props when the component is created.