### PR TITLE
Expose camera authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,14 @@ Supported options:
  - `metadata` This is metadata to be added to the captured image.
    - `location` This is the object returned from `navigator.geolocation.getCurrentPosition()` (React Native's geolocation polyfill). It will add GPS metadata to the image.
  - `rotation` This will rotate the image by the number of degrees specified.
- 
+
 #### `stopCapture()`
 
 Ends the current capture session for video captures. Only applies when the current `captureMode` is `video`.
+
+### `checkDeviceAuthorizationStatus(callback(err, isAuthorized))`
+
+Exposes the native API for checking if the device has authorized access to the camera. Can be used to call before loading the Camera component to ensure proper UX.
 
 ## Subviews
 This component supports subviews, so if you wish to use the camera view as a background or if you want to layout buttons/images/etc. inside the camera then you can do that.

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Supported options:
 
 Ends the current capture session for video captures. Only applies when the current `captureMode` is `video`.
 
-### `checkDeviceAuthorizationStatus(callback(err, isAuthorized))`
+#### `checkDeviceAuthorizationStatus(callback(err, isAuthorized))`
 
 Exposes the native API for checking if the device has authorized access to the camera. Can be used to call before loading the Camera component to ensure proper UX.
 

--- a/index.ios.js
+++ b/index.ios.js
@@ -11,7 +11,7 @@ var constants = {
   CaptureTarget: NativeModules.CameraManager.CaptureTarget,
   Orientation: NativeModules.CameraManager.Orientation,
   FlashMode: NativeModules.CameraManager.FlashMode,
-  TorchMode: NativeModules.CameraManager.TorchMode,
+  TorchMode: NativeModules.CameraManager.TorchMode
 };
 
 var Camera = React.createClass({
@@ -84,7 +84,7 @@ var Camera = React.createClass({
 
   componentWillUnmount() {
     this.cameraBarCodeReadListener.remove();
-    
+
     if (this.state.isRecording) {
       this.stopCapture();
     }
@@ -120,7 +120,7 @@ var Camera = React.createClass({
     if (typeof aspect === 'string') {
       aspect = constants.Aspect[aspect];
     }
-    
+
     if (typeof flashMode === 'string') {
       flashMode = constants.FlashMode[flashMode];
     }
@@ -128,7 +128,7 @@ var Camera = React.createClass({
     if (typeof orientation === 'string') {
       orientation = constants.Orientation[orientation];
     }
-    
+
     if (typeof torchMode === 'string') {
       torchMode = constants.TorchMode[torchMode];
     }
@@ -169,7 +169,7 @@ var Camera = React.createClass({
     if (typeof options.mode === 'string') {
       options.mode = constants.CaptureMode[options.mode];
     }
-    
+
     if (options.mode === constants.CaptureMode.video) {
       options.totalSeconds = (options.totalSeconds > -1 ? options.totalSeconds : -1);
       options.preferredTimeScale = options.preferredTimeScale || 30;
@@ -199,4 +199,6 @@ var styles = StyleSheet.create({
 });
 
 Camera.constants = constants;
+Camera.checkDeviceAuthorizationStatus = NativeModules.CameraManager.checkDeviceAuthorizationStatus
+
 module.exports = Camera;


### PR DESCRIPTION
In response to issue #134, I added the `checkDeviceAuthorizationStatus` method to the Camera reference API. Since it's not a value list, I opted to not add it to the `constants` var.