### PR TITLE
Fix: Wrong image orientation when device orientation is locked

### DIFF
--- a/ios/RCTCamera.h
+++ b/ios/RCTCamera.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
 #import "CameraFocusSquare.h"
+#import <CoreMotion/CoreMotion.h>
 
 @class RCTCameraManager;
 
@@ -9,6 +10,7 @@
 @property (nonatomic) RCTCameraManager *manager;
 @property (nonatomic) RCTBridge *bridge;
 @property (nonatomic) RCTCameraFocusSquare *camFocus;
+@property (nonatomic, strong) CMMotionManager *motionManager;
 
 - (id)initWithManager:(RCTCameraManager*)manager bridge:(RCTBridge *)bridge;
 

--- a/ios/RCTCameraManager.h
+++ b/ios/RCTCameraManager.h
@@ -60,6 +60,7 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 @property (nonatomic) NSInteger videoTarget;
 @property (nonatomic, strong) RCTResponseSenderBlock videoCallback;
 @property (nonatomic, strong) RCTCamera *camera;
+@property (nonatomic) NSInteger saveImageOrientation;
 
 
 - (void)changeAspect:(NSString *)aspect;
@@ -75,6 +76,7 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 - (void)stopSession;
 - (void)focusAtThePoint:(CGPoint) atPoint;
 - (void)zoom:(CGFloat)velocity reactTag:(NSNumber *)reactTag;
+- (void)changeSaveImageOrientation:(NSInteger)orientation;
 
 
 @end

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -373,7 +373,7 @@ RCT_EXPORT_METHOD(stopCapture) {
       NSData *imageData = UIImageJPEGRepresentation(image, 1.0);
       [self saveImage:imageData target:target metadata:nil callback:callback];
 #else
-      [[self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo] setVideoOrientation:self.previewLayer.connection.videoOrientation];
+      [[self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo] setVideoOrientation:self.saveImageOrientation];
 
       [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:[self.stillImageOutput connectionWithMediaType:AVMediaTypeVideo] completionHandler:^(CMSampleBufferRef imageDataSampleBuffer, NSError *error) {
 
@@ -737,6 +737,11 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
     } else {
         NSLog(@"error: %@", error);
     }
+}
+
+- (void) changeSaveImageOrientation:(NSInteger)orientation
+{
+  self.saveImageOrientation = orientation;
 }
 
 


### PR DESCRIPTION
I fixed the bug that the image saved as portrait orientation when the device auto orientation lock mode.
Because UIDeviceOrientationDidChangeNotification is not worked in the locked mode.
(I attached the picture which show the locked mode.)

You need to import **CoreMotion.framework** to make it work.

![_000](https://cloud.githubusercontent.com/assets/2346203/12032185/caa038dc-ae58-11e5-9989-5ba58d5bb13a.png)
