### PR TITLE
orientation in landscape initializes properly

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -213,7 +213,16 @@ RCT_EXPORT_METHOD(changeFlashMode:(NSInteger)flashMode) {
 }
 
 RCT_EXPORT_METHOD(changeOrientation:(NSInteger)orientation) {
-  self.previewLayer.connection.videoOrientation = orientation;
+  if (self.previewLayer.connection.isVideoOrientationSupported) {
+    self.previewLayer.connection.videoOrientation = orientation;
+  }
+  else {
+    // Setting videoOrientation isn't yet supported, so we have to wait until
+    // startSession has finished to set it. Put this in the queue behind.
+    dispatch_async(self.sessionQueue, ^{
+      self.previewLayer.connection.videoOrientation = orientation;
+    });
+  }
 }
 
 RCT_EXPORT_METHOD(changeTorchMode:(NSInteger)torchMode) {


### PR DESCRIPTION
This is a fix for #76. An explanation of the problematic behavior can be found there.

It turns out that if we try to set the `connection.videoOrientation` before the code in `startSession` has been called, the connection rejects the change. This PR fixes the problem by detecting whether the `connection` is ready to have `videoOrientation` set on it. If it is, it sets it directly. If not, it enqueues it in the `sessionQueue`, which causes the orientation to be set *after* `startSession` has finished.