### PR TITLE
add keepAwake prop

### DIFF
--- a/Camera.js
+++ b/Camera.js
@@ -67,6 +67,7 @@ export default class Camera extends Component {
       PropTypes.string,
       PropTypes.number
     ]),
+    keepAwake: PropTypes.bool,
     onBarCodeRead: PropTypes.func,
     onFocusChanged: PropTypes.func,
     onZoomChanged: PropTypes.func,

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ If `defaultOnFocusComponent` set to false, default internal implementation of vi
 Called when focus has changed.
 By default, `onZoomChanged` is not defined and pinch-to-zoom is disabled.
 
+#### `iOS` `keepAwake`
+
+If set to `true`, the device will not sleep while the camera preview is visible. This mimics the behavior of the default camera app, which keeps the device awake while open.
+
 ## Component instance methods
 
 You can access component methods by adding a `ref` (ie. `ref="camera"`) prop to your `<Camera>` element, then you can use `this.refs.camera.capture(cb)`, etc. inside your component.

--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -16,6 +16,7 @@
   BOOL _onFocusChanged;
   BOOL _defaultOnFocusComponent;
   BOOL _onZoomChanged;
+  BOOL _previousIdleTimerDisabled;
 }
 
 - (void)setAspect:(NSInteger)aspect
@@ -90,6 +91,13 @@
   }
 }
 
+- (void)setKeepAwake:(BOOL)enabled
+{
+  if (enabled) {
+    [UIApplication sharedApplication].idleTimerDisabled = true;
+  }
+}
+
 - (id)initWithManager:(RCTCameraManager*)manager bridge:(RCTBridge *)bridge
 {
   
@@ -104,6 +112,7 @@
     _onFocusChanged = NO;
     _defaultOnFocusComponent = YES;
     _onZoomChanged = NO;
+    _previousIdleTimerDisabled = [UIApplication sharedApplication].idleTimerDisabled;
   }
   return self;
 }
@@ -133,6 +142,7 @@
   [self.manager stopSession];
   [super removeFromSuperview];
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
+  [UIApplication sharedApplication].idleTimerDisabled = _previousIdleTimerDisabled;
 }
 
 - (void)orientationChanged:(NSNotification *)notification{

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -30,6 +30,7 @@ RCT_EXPORT_VIEW_PROPERTY(type, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(orientation, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(flashMode, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(torchMode, NSInteger);
+RCT_EXPORT_VIEW_PROPERTY(keepAwake, BOOL);
 
 - (NSDictionary *)constantsToExport
 {


### PR DESCRIPTION
This change adds a `keepAwake` prop to the video component (iOS only at the moment because that's where I'm using it, although adding android support wouldn't be hard). Setting this to true will keep the display on as long as the `Camera` component is visible on the screen, which is the same behavior as the default iOS camera app.

This is especially useful when video recording, because currently if you want to record a video longer than the length of your screen timeout you have to keep tapping the phone to keep it awake. :+1: 