### PR TITLE
fix capture method errors and preview not working

### DIFF
--- a/Camera.js
+++ b/Camera.js
@@ -142,6 +142,7 @@ export default class Camera extends Component {
       audio: props.captureAudio,
       mode: props.captureMode,
       target: props.captureTarget,
+      type: props.type,
       ...options
     };
 

--- a/Camera.js
+++ b/Camera.js
@@ -143,6 +143,8 @@ export default class Camera extends Component {
       mode: props.captureMode,
       target: props.captureTarget,
       type: props.type,
+      title: '',
+      description: '',
       ...options
     };
 

--- a/Camera.js
+++ b/Camera.js
@@ -4,7 +4,8 @@ import React, {
   NativeModules,
   PropTypes,
   StyleSheet,
-  requireNativeComponent
+  requireNativeComponent,
+  View,
 } from 'react-native';
 
 const CameraManager = NativeModules.CameraManager || NativeModules.CameraModule;
@@ -49,6 +50,7 @@ export default class Camera extends Component {
   };
   
   static propTypes = {
+    ...View.propTypes,
     aspect: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,6 +22,7 @@ android {
   }
   lintOptions {
     abortOnError false
+    warning 'InvalidPackage'
   }
 }
 
@@ -30,5 +31,5 @@ repositories {
 }
 
 dependencies {
-  compile "com.facebook.react:react-native:0.17.+"
+  compile "com.facebook.react:react-native:0.19.+"
 }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewManager.java
@@ -2,9 +2,10 @@ package com.lwansbrough.RCTCamera;
 
 import android.support.annotation.Nullable;
 import com.facebook.react.uimanager.*;
+import com.facebook.react.uimanager.annotations.ReactProp;
 
-public class RCTCameraViewManager extends SimpleViewManager<RCTCameraView> {
-    private static final String REACT_CLASS = "RCTCameraView";
+public class RCTCameraViewManager extends ViewGroupManager<RCTCameraView> {
+    private static final String REACT_CLASS = "RCTCamera";
 
     @Override
     public String getName() {


### PR DESCRIPTION
This PR use the changes of #176  pull request to get working preview on Android with react native 0.19. Then anyway I still having some issues like this one when using capture() method (same with type/title/description). Issues: #185, #167 : 

``` 
Exception in native call from JS
unknown:React: com.facebook.react.bridge.NoSuchKeyException: couldn't find key type in dynamic object
unknown:React:  at com.facebook.react.bridge.ReadableNativeMap.getInt(Native Method)
unknown:React:  at com.lwansbrough.RCTCamera.RCTCameraModule.capture(RCTCameraModule.java:154)
unknown:React:  at java.lang.reflect.Method.invoke(Native Method)
```