### PR TITLE
Add support for ITF14 and interleaved 2 of 5 barcode types

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ The following barcode types can be recognised:
 - `pdf417`
 - `qr`
 - `upce`
+- `interleaved2of5` (when available)
+- `itf14` (when available)
 - `datamatrix` (when available)
 
 The barcode type is provided in the `data` object.

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -50,6 +50,12 @@ RCT_EXPORT_VIEW_PROPERTY(torchMode, NSInteger);
                    @"pdf417": AVMetadataObjectTypePDF417Code,
                    @"qr": AVMetadataObjectTypeQRCode,
                    @"aztec": AVMetadataObjectTypeAztecCode
+                   #ifdef AVMetadataObjectTypeInterleaved2of5Code
+                   ,@"interleaved2of5": AVMetadataObjectTypeInterleaved2of5Code
+                   # endif
+                   #ifdef AVMetadataObjectTypeITF14Code
+                   ,@"itf14": AVMetadataObjectTypeITF14Code
+                   # endif
                    #ifdef AVMetadataObjectTypeDataMatrixCode
                    ,@"datamatrix": AVMetadataObjectTypeDataMatrixCode
                    # endif
@@ -100,6 +106,12 @@ RCT_EXPORT_VIEW_PROPERTY(torchMode, NSInteger);
     AVMetadataObjectTypePDF417Code,
     AVMetadataObjectTypeQRCode,
     AVMetadataObjectTypeAztecCode
+    #ifdef AVMetadataObjectTypeInterleaved2of5Code
+    ,AVMetadataObjectTypeInterleaved2of5Code
+    # endif
+    #ifdef AVMetadataObjectTypeITF14Code
+    ,AVMetadataObjectTypeITF14Code
+    # endif
     #ifdef AVMetadataObjectTypeDataMatrixCode
     ,AVMetadataObjectTypeDataMatrixCode
     # endif


### PR DESCRIPTION
First of all, Thanks for this great library! 

Based on  Apple docs ([https://developer.apple.com/library/prerelease/ios/documentation/AVFoundation/Reference/AVMetadataMachineReadableCodeObject_Class/index.html#//apple_ref/doc/constant_group/Machine_Readable_Object_Types](url)) the following popular bar code types are also supported:

- ITF14 (AVMetadataObjectTypeITF14Code)
- interleaved 2 of 5 (AVMetadataObjectTypeInterleaved2of5Code)

I've tried myself and it works fine.