### PR TITLE
Fixes infinite loop in RCTCamera.layoutSubviews

### DIFF
--- a/ios/RCTCamera.h
+++ b/ios/RCTCamera.h
@@ -9,6 +9,7 @@
 @property (nonatomic) RCTCameraManager *manager;
 @property (nonatomic) RCTBridge *bridge;
 @property (nonatomic) RCTCameraFocusSquare *camFocus;
+@property (nonatomic) AVCaptureVideoPreviewLayer *previewLayer;
 
 - (id)initWithManager:(RCTCameraManager*)manager bridge:(RCTBridge *)bridge;
 

--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -104,6 +104,7 @@
   if ((self = [super init])) {
     self.manager = manager;
     self.bridge = bridge;
+    self.previewLayer = [AVCaptureVideoPreviewLayer layerWithSession:self.manager.session];
     UIPinchGestureRecognizer *pinchGesture = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handlePinchToZoomRecognizer:)];
     [self addGestureRecognizer:pinchGesture];
     [self.manager initializeCaptureSessionInput:AVMediaTypeVideo];
@@ -120,9 +121,9 @@
 - (void)layoutSubviews
 {
   [super layoutSubviews];
-  self.manager.previewLayer.frame = self.bounds;
+  self.previewLayer.frame = self.bounds;
   [self setBackgroundColor:[UIColor blackColor]];
-  [self.layer insertSublayer:self.manager.previewLayer atIndex:0];
+  [self.layer insertSublayer:self.previewLayer atIndex:0];
 }
 
 - (void)insertReactSubview:(UIView *)view atIndex:(NSInteger)atIndex


### PR DESCRIPTION
When someone activates multiple `<Camera>` components, for example, if they double tap a navigator button that opens a View with a `<Camera>` component, RCTCamera.m will call `[super layoutSubviews];` in an infinite loop. I believe it has to do with the shared `self.manager.previewLayer`. When one RCTCamera instance sets the `frame` on the same shared previewLayer, the other RCTCamera instance has its `layoutSubviews` called, it sets the frame, and the first one has `layoutSubviews` and they just keep handing off to each other infinitely. 

This patch has each RCTCamera instance allocate and manage its own preview layer. The disadvantage is that this previewLayer wont respond to `RCTCameraManger.changeAspect` and `RCTCameraManager.changeOrientation`. Open to other solutions.