### PR TITLE
Fix zoomFactor getting reset to 1.0 when it goes above the max.

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -821,7 +821,11 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
     AVCaptureDevice *device = [[self videoCaptureDeviceInput] device];
     if ([device lockForConfiguration:&error]) {
         CGFloat zoomFactor = device.videoZoomFactor + atan(velocity / pinchVelocityDividerFactor);
-        zoomFactor = zoomFactor >= 1 && zoomFactor <= device.activeFormat.videoMaxZoomFactor ? zoomFactor : 1.0f;
+        if (zoomFactor > device.activeFormat.videoMaxZoomFactor) {
+            zoomFactor = device.activeFormat.videoMaxZoomFactor;
+        } else if (zoomFactor < 1) {
+            zoomFactor = 1.0f;
+        }
 
         NSDictionary *event = @{
           @"target": reactTag,


### PR DESCRIPTION
The zoomFactor should get set the max, not 1.0, when it goes above the max, otherwise, when you go past the max, it resets the zoom to 1.0 and just keeps re-zooming in while spreading your fingers.