### PR TITLE
transform barcode metadata points to screen coordinates

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -698,18 +698,20 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
   for (AVMetadataMachineReadableCodeObject *metadata in metadataObjects) {
     for (id barcodeType in [self getBarCodeTypes]) {
       if (metadata.type == barcodeType) {
+        // Transform the meta-data coordinates to screen coords
+        AVMetadataMachineReadableCodeObject *transformed = (AVMetadataMachineReadableCodeObject *)[_previewLayer transformedMetadataObjectForMetadataObject:metadata];
         
         NSDictionary *event = @{
           @"type": metadata.type,
           @"data": metadata.stringValue,
           @"bounds": @{
             @"origin": @{
-              @"x": [NSString stringWithFormat:@"%f", metadata.bounds.origin.x],
-              @"y": [NSString stringWithFormat:@"%f", metadata.bounds.origin.y]
+              @"x": [NSString stringWithFormat:@"%f", transformed.bounds.origin.x],
+              @"y": [NSString stringWithFormat:@"%f", transformed.bounds.origin.y]
             },
             @"size": @{
-              @"height": [NSString stringWithFormat:@"%f", metadata.bounds.size.height],
-              @"width": [NSString stringWithFormat:@"%f", metadata.bounds.size.width],
+              @"height": [NSString stringWithFormat:@"%f", transformed.bounds.size.height],
+              @"width": [NSString stringWithFormat:@"%f", transformed.bounds.size.width],
             }
           }
         };


### PR DESCRIPTION
The `onBarCodeRead` event provides bounds-- but they are in a not-so-useful points format. This will convert them into _real_ screen coordinates.