### PR TITLE
Add hasFlash support for Android

### DIFF
--- a/Camera.js
+++ b/Camera.js
@@ -2,6 +2,7 @@ import React, {
   Component,
   NativeAppEventEmitter,
   NativeModules,
+  Platform,
   PropTypes,
   StyleSheet,
   requireNativeComponent,
@@ -181,6 +182,12 @@ export default class Camera extends Component {
   }
 
   hasFlash() {
+    if (Platform.OS === 'android') {
+      const props = convertStringProps(this.props);
+      return CameraManager.hasFlash({
+        type: props.type
+      });
+    }
     return CameraManager.hasFlash();
   }
 }

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Supported options:
 
 Returns the camera's current field of view.
 
-#### `iOS` `hasFlash(): Promise`
+#### `hasFlash(): Promise`
 
 Returns whether or not the camera has flash capabilities.
 

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 public class RCTCameraModule extends ReactContextBaseJavaModule {
     private static final String TAG = "RCTCameraModule";
@@ -232,6 +233,16 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void stopCapture(final ReadableMap options, final Promise promise) {
         // TODO: implement video capture
+    }
+
+    @ReactMethod
+    public void hasFlash(ReadableMap options, final Promise promise) {
+        Camera camera = RCTCamera.getInstance().acquireCameraInstance(options.getInt("type"));
+        if (null == camera) {
+            promise.reject("No camera found.");
+        }
+        List<String> flashModes = camera.getParameters().getSupportedFlashModes();
+        promise.resolve(null != flashModes && !flashModes.isEmpty());
     }
 
     private File getOutputMediaFile(int type) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -240,6 +240,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
         Camera camera = RCTCamera.getInstance().acquireCameraInstance(options.getInt("type"));
         if (null == camera) {
             promise.reject("No camera found.");
+            return;
         }
         List<String> flashModes = camera.getParameters().getSupportedFlashModes();
         promise.resolve(null != flashModes && !flashModes.isEmpty());


### PR DESCRIPTION
The following changes add hasFlash() support to Android. It uses same semantics as hasFlash() for iOS.