### PR TITLE
Faster video file processing

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -689,8 +689,8 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
     NSFileManager * fileManager = [NSFileManager defaultManager];
     NSError * error = nil;
 
-    //copying destination
-    if (!([fileManager copyItemAtPath:[outputFileURL path] toPath:fullPath error:&error])) {
+    //moving to destination
+    if (!([fileManager moveItemAtPath:[outputFileURL path] toPath:fullPath error:&error])) {
       self.videoReject(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));
       return;
     }
@@ -703,8 +703,8 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
     NSFileManager * fileManager = [NSFileManager defaultManager];
     NSError * error = nil;
       
-    //copying destination
-    if (!([fileManager copyItemAtPath:[outputFileURL path] toPath:fullPath error:&error])) {
+    //moving to destination
+    if (!([fileManager moveItemAtPath:[outputFileURL path] toPath:fullPath error:&error])) {
         self.videoReject(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));
         return;
     }


### PR DESCRIPTION
This PR drastically speeds up the processing time for large video files, as well as leading to lower overall disk usage. It accomplishes this by moving video into their final destination instead of copying them (and relying on the system to GC the old temp file).

Previously a 2-minute HD recording would take ~10s on my phone to finish processing once I called `stopCapture`; with this change it takes less than a second.