### PR TITLE
Init preview each time view requested

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -22,7 +22,12 @@ RCT_EXPORT_MODULE();
 
 - (UIView *)view
 {
-    return [[RCTCamera alloc] initWithManager:self bridge:self.bridge];
+  self.session = [AVCaptureSession new];
+  
+  self.previewLayer = [AVCaptureVideoPreviewLayer layerWithSession:self.session];
+  self.previewLayer.needsDisplayOnBoundsChange = YES;
+
+  return [[RCTCamera alloc] initWithManager:self bridge:self.bridge];
 }
 
 RCT_EXPORT_VIEW_PROPERTY(aspect, NSInteger);
@@ -142,18 +147,10 @@ RCT_EXPORT_VIEW_PROPERTY(onZoomChanged, BOOL)
 }
 
 - (id)init {
-
   if ((self = [super init])) {
     self.mirrorImage = false;
 
-    self.session = [AVCaptureSession new];
-
-    self.previewLayer = [AVCaptureVideoPreviewLayer layerWithSession:self.session];
-    self.previewLayer.needsDisplayOnBoundsChange = YES;
-
     self.sessionQueue = dispatch_queue_create("cameraManagerQueue", DISPATCH_QUEUE_SERIAL);
-
-
   }
   return self;
 }


### PR DESCRIPTION
Currently, the `AVCaptureSession` and `AVCaptureVideoPreviewLayer` are only initialized once on library init, and are reused between subsequent sessions.

This mostly works fine, but it does have some drawbacks. Specifically, (1) when the camera is re-opened there's a momentary flash of whatever was last in the preview window last time it was closed and (2) occasionally when you've opened the camera in one orientation, close it, and then reopen it with the device in a different orientation, the camera either never updates its orientation or takes a long time (8-10 seconds) to do so. This issue has been reproduced on an iPhone 5C and iPhone 6, both running iOS 9.2.

This PR reinitializes the session and previewLayer on each request for a camera view. This doesn't have much of a performance impact because most of the expensive operations happen in `startSession` (which was being called each time anyway) so the time from mounting the `<Camera />` to having a live preview isn't noticeably longer with this change, it just does a better job of ensuring correctness.