### PR TITLE
Set the right preview orientation before startup

### DIFF
--- a/ios/RCTCameraManager.h
+++ b/ios/RCTCameraManager.h
@@ -59,6 +59,7 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 @property (nonatomic, assign) NSInteger presetCamera;
 @property (nonatomic, strong) AVCaptureVideoPreviewLayer *previewLayer;
 @property (nonatomic, assign) NSInteger videoTarget;
+@property (nonatomic, assign) NSInteger orientation;
 @property (nonatomic, assign) BOOL mirrorImage;
 @property (nonatomic, strong) RCTPromiseResolveBlock videoResolve;
 @property (nonatomic, strong) RCTPromiseRejectBlock videoReject;

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -236,18 +236,12 @@ RCT_EXPORT_METHOD(changeFlashMode:(NSInteger)flashMode) {
 }
 
 RCT_EXPORT_METHOD(changeOrientation:(NSInteger)orientation) {
+  [self setOrientation:orientation];
   if (self.previewLayer.connection.isVideoOrientationSupported) {
     self.previewLayer.connection.videoOrientation = orientation;
   }
-  else {
-    // Setting videoOrientation isn't yet supported, so we have to wait until
-    // startSession has finished to set it. Put this in the queue behind.
-    dispatch_async(self.sessionQueue, ^{
-      self.previewLayer.connection.videoOrientation = orientation;
-    });
-  }
 }
-
+  
 RCT_EXPORT_METHOD(changeMirrorImage:(BOOL)mirrorImage) {
   self.mirrorImage = mirrorImage;
 }
@@ -365,6 +359,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
       });
     }]];
 
+    [self.previewLayer.connection setVideoOrientation:self.orientation];
     [self.session startRunning];
   });
 }


### PR DESCRIPTION
In https://github.com/lwansbrough/react-native-camera/pull/183 I added functionality to correctly set video orientation at camera initialization. That code worked, but by delaying the setting of orientation until after the camera was loaded there was an undesirable flash of a preview in the wrong orientation before the correct one appeared.

This new solution sets the correct video orientation as part of the `startSession` block before the preview is loaded, getting rid of the momentary wrong orientation. This has been fully tested and works better than the old solution.