### PR TITLE
Search only defined barcodes to improve performance

### DIFF
--- a/Camera.js
+++ b/Camera.js
@@ -84,6 +84,7 @@ export default class Camera extends Component {
     onFocusChanged: PropTypes.func,
     onZoomChanged: PropTypes.func,
     mirrorImage: PropTypes.bool,
+    barCodeTypes: PropTypes.array,
     orientation: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number
@@ -110,6 +111,7 @@ export default class Camera extends Component {
     flashMode: CameraManager.FlashMode.off,
     torchMode: CameraManager.TorchMode.off,
     mirrorImage: false,
+    barCodeTypes: [],
   };
 
   static checkDeviceAuthorizationStatus = CameraManager.checkDeviceAuthorizationStatus;

--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -73,6 +73,11 @@
   [self.manager changeMirrorImage:mirrorImage];
 }
 
+- (void)setBarCodeTypes:(NSArray *)barCodeTypes
+{
+    [self.manager changeBarCodeTypes:barCodeTypes];
+}
+
 - (void)setFlashMode:(NSInteger)flashMode
 {
   [self.manager changeFlashMode:flashMode];

--- a/ios/RCTCameraManager.h
+++ b/ios/RCTCameraManager.h
@@ -61,6 +61,7 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 @property (nonatomic, assign) NSInteger videoTarget;
 @property (nonatomic, assign) NSInteger orientation;
 @property (nonatomic, assign) BOOL mirrorImage;
+@property (nonatomic, strong) NSArray* barCodeTypes;
 @property (nonatomic, strong) RCTPromiseResolveBlock videoResolve;
 @property (nonatomic, strong) RCTPromiseRejectBlock videoReject;
 @property (nonatomic, strong) RCTCamera *camera;
@@ -70,6 +71,7 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 - (void)changeCamera:(NSInteger)camera;
 - (void)changeOrientation:(NSInteger)orientation;
 - (void)changeMirrorImage:(BOOL)mirrorImage;
+- (void)changeBarCodeTypes:(NSArray *)barCodeTypes;
 - (void)changeFlashMode:(NSInteger)flashMode;
 - (void)changeTorchMode:(NSInteger)torchMode;
 - (AVCaptureDevice *)deviceWithMediaType:(NSString *)mediaType preferringPosition:(AVCaptureDevicePosition)position;

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -37,6 +37,7 @@ RCT_EXPORT_VIEW_PROPERTY(flashMode, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(torchMode, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(keepAwake, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(mirrorImage, BOOL);
+RCT_EXPORT_VIEW_PROPERTY(barCodeTypes, NSArray);
 
 - (NSDictionary *)constantsToExport
 {
@@ -111,27 +112,7 @@ RCT_EXPORT_VIEW_PROPERTY(mirrorImage, BOOL);
 }
 
 - (NSArray *)getBarCodeTypes {
-  return @[
-    AVMetadataObjectTypeUPCECode,
-    AVMetadataObjectTypeCode39Code,
-    AVMetadataObjectTypeCode39Mod43Code,
-    AVMetadataObjectTypeEAN13Code,
-    AVMetadataObjectTypeEAN8Code,
-    AVMetadataObjectTypeCode93Code,
-    AVMetadataObjectTypeCode128Code,
-    AVMetadataObjectTypePDF417Code,
-    AVMetadataObjectTypeQRCode,
-    AVMetadataObjectTypeAztecCode
-    #ifdef AVMetadataObjectTypeInterleaved2of5Code
-    ,AVMetadataObjectTypeInterleaved2of5Code
-    # endif
-    #ifdef AVMetadataObjectTypeITF14Code
-    ,AVMetadataObjectTypeITF14Code
-    # endif
-    #ifdef AVMetadataObjectTypeDataMatrixCode
-    ,AVMetadataObjectTypeDataMatrixCode
-    # endif
-  ];
+  return self.barCodeTypes;
 }
 
 RCT_EXPORT_VIEW_PROPERTY(defaultOnFocusComponent, BOOL);

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -37,7 +37,7 @@ RCT_EXPORT_VIEW_PROPERTY(flashMode, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(torchMode, NSInteger);
 RCT_EXPORT_VIEW_PROPERTY(keepAwake, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(mirrorImage, BOOL);
-RCT_EXPORT_VIEW_PROPERTY(barCodeTypes, NSArray);
+RCT_EXPORT_VIEW_PROPERTY(barCodeTypes, NSStringArray);
 
 - (NSDictionary *)constantsToExport
 {
@@ -244,6 +244,10 @@ RCT_EXPORT_METHOD(changeMirrorImage:(BOOL)mirrorImage) {
   self.mirrorImage = mirrorImage;
 }
 
+RCT_EXPORT_METHOD(changeBarCodeTypes:(NSArray *)barCodeTypes) {
+    self.barCodeTypes = barCodeTypes;
+}
+
 RCT_EXPORT_METHOD(changeTorchMode:(NSInteger)torchMode) {
   AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
   NSError *error = nil;
@@ -344,7 +348,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
     if ([self.session canAddOutput:metadataOutput]) {
       [metadataOutput setMetadataObjectsDelegate:self queue:self.sessionQueue];
       [self.session addOutput:metadataOutput];
-      [metadataOutput setMetadataObjectTypes:metadataOutput.availableMetadataObjectTypes];
+      [metadataOutput setMetadataObjectTypes:self.barCodeTypes];
       self.metadataOutput = metadataOutput;
     }
 

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -716,7 +716,7 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
 
   for (AVMetadataMachineReadableCodeObject *metadata in metadataObjects) {
     for (id barcodeType in [self getBarCodeTypes]) {
-      if (metadata.type == barcodeType) {
+      if ([metadata.type isEqualToString:barcodeType]) {
         // Transform the meta-data coordinates to screen coords
         AVMetadataMachineReadableCodeObject *transformed = (AVMetadataMachineReadableCodeObject *)[_previewLayer transformedMetadataObjectForMetadataObject:metadata];
 


### PR DESCRIPTION
We highly recommend to merge this to massively improve performance and not look for barcodes if u just want to take images or something. In our case we are just searching for qr codes, which is done way faster now.

This is just done in iOS and should also be implemented for Android. 

Someone may also want to reflect this in ReadMe.
`barCodeTypes={[Camera.constants.BarCodeType.qr]}`

Keep up the great work!:)