### PR TITLE
Increase cohesion of iOS property methods

### DIFF
--- a/Camera.js
+++ b/Camera.js
@@ -122,7 +122,7 @@ export default class Camera extends Component {
     playSoundOnCapture: true,
     torchMode: CameraManager.TorchMode.off,
     mirrorImage: false,
-    barCodeTypes: Object.keys(CameraManager.BarCodeType),
+    barCodeTypes: Object.values(CameraManager.BarCodeType),
   };
 
   static checkDeviceAuthorizationStatus = CameraManager.checkDeviceAuthorizationStatus;
@@ -142,9 +142,9 @@ export default class Camera extends Component {
   }
 
   async componentWillMount() {
-    this.cameraBarCodeReadListener = NativeAppEventEmitter.addListener('CameraBarCodeRead', this.props.onBarCodeRead);
+    this.cameraBarCodeReadListener = NativeAppEventEmitter.addListener('CameraBarCodeRead', this._onBarCodeRead);
 
-    let { captureMode } = convertStringProps({captureMode: this.props.captureMode})
+    let { captureMode } = convertNativeProps({captureMode: this.props.captureMode})
     let hasVideoAndAudio = this.props.captureAudio && captureMode === Camera.constants.CaptureMode.video
     let check = hasVideoAndAudio ? Camera.checkDeviceAuthorizationStatus : Camera.checkVideoAuthorizationStatus;
 
@@ -168,6 +168,10 @@ export default class Camera extends Component {
 
     return <RCTCamera ref={CAMERA_REF} {...nativeProps} />;
   }
+
+  _onBarCodeRead = (data) => {
+    if (this.props.onBarCodeRead) this.props.onBarCodeRead(data)
+  };
 
   capture(options) {
     const props = convertNativeProps(this.props);
@@ -206,7 +210,7 @@ export default class Camera extends Component {
 
   hasFlash() {
     if (Platform.OS === 'android') {
-      const props = convertStringProps(this.props);
+      const props = convertNativeProps(this.props);
       return CameraManager.hasFlash({
         type: props.type
       });

--- a/Camera.js
+++ b/Camera.js
@@ -12,7 +12,7 @@ import React, {
 const CameraManager = NativeModules.CameraManager || NativeModules.CameraModule;
 const CAMERA_REF = 'camera';
 
-function convertStringProps(props) {
+function convertNativeProps(props) {
   const newProps = { ...props };
   if (typeof props.aspect === 'string') {
     newProps.aspect = Camera.constants.Aspect[props.aspect];
@@ -36,6 +36,11 @@ function convertStringProps(props) {
 
   if (typeof props.captureQuality === 'string') {
     newProps.captureQuality = Camera.constants.CaptureQuality[props.captureQuality];
+  }
+
+  // do not register barCodeTypes if no barcode listener
+  if (typeof props.onBarCodeRead !== 'function') {
+    newProps.barCodeTypes = [];
   }
 
   return newProps;
@@ -113,7 +118,7 @@ export default class Camera extends Component {
     playSoundOnCapture: true,
     torchMode: CameraManager.TorchMode.off,
     mirrorImage: false,
-    barCodeTypes: [],
+    barCodeTypes: Object.keys(CameraManager.BarCodeType),
   };
 
   static checkDeviceAuthorizationStatus = CameraManager.checkDeviceAuthorizationStatus;
@@ -153,15 +158,16 @@ export default class Camera extends Component {
 
   render() {
     const style = [styles.base, this.props.style];
-    const nativeProps = convertStringProps(this.props);
+    const nativeProps = convertNativeProps(this.props);
 
     return <RCTCamera ref={CAMERA_REF} {...nativeProps} />;
   }
 
   capture(options) {
-    const props = convertStringProps(this.props);
+    const props = convertNativeProps(this.props);
     options = {
       audio: props.captureAudio,
+      barCodeTypes: props.barCodeTypes,
       mode: props.captureMode,
       target: props.captureTarget,
       quality: props.captureQuality,

--- a/Camera.js
+++ b/Camera.js
@@ -168,6 +168,7 @@ export default class Camera extends Component {
     options = {
       audio: props.captureAudio,
       barCodeTypes: props.barCodeTypes,
+      playSoundOnCapture: props.playSoundOnCapture,
       mode: props.captureMode,
       target: props.captureTarget,
       quality: props.captureQuality,

--- a/Camera.js
+++ b/Camera.js
@@ -113,7 +113,7 @@ export default class Camera extends Component {
   };
 
   static checkDeviceAuthorizationStatus = CameraManager.checkDeviceAuthorizationStatus;
-  static checkVideoAuthorizationStatus = CameraManager.checkCameraAuthorizationStatus;
+  static checkVideoAuthorizationStatus = CameraManager.checkVideoAuthorizationStatus;
   static checkAudioAuthorizationStatus = CameraManager.checkAudioAuthorizationStatus;
 
   setNativeProps(props) {

--- a/Camera.js
+++ b/Camera.js
@@ -88,6 +88,7 @@ export default class Camera extends Component {
       PropTypes.string,
       PropTypes.number
     ]),
+    playSoundOnCapture: PropTypes.bool,
     torchMode: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number
@@ -108,6 +109,7 @@ export default class Camera extends Component {
     captureQuality: CameraManager.CaptureQuality.high,
     defaultOnFocusComponent: true,
     flashMode: CameraManager.FlashMode.off,
+    playSoundOnCapture: true,
     torchMode: CameraManager.TorchMode.off,
     mirrorImage: false,
   };

--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ Values:
 
 The `orientation` property allows you to specify the current orientation of the phone to ensure the viewfinder is "the right way up."
 
+#### `Android` `playSoundOnCapture`
+
+Values: `true` (default) or `false`
+
+This property allows you to specify whether a sound is played on capture
+
 #### `iOS` `onBarCodeRead`
 
 Will call the specified method when a barcode is detected in the camera's view.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,6 @@ A camera module for React Native.
 
 ![](https://i.imgur.com/5j2JdUk.gif)
 
-## Known Issues
-Below is a list of known issues. Pull requests are welcome for any of these issues!
-- Android support is only available through GitHub at the moment. The npm package does not have a working Android implementation.
-- Stills captured to disk will not be cleaned up and thus must be managed manually for now
-
 ## Getting started
 ### Mostly automatic install
 1. `npm install rnpm --global`
@@ -164,7 +159,7 @@ The `orientation` property allows you to specify the current orientation of the 
 
 Values: `true` (default) or `false`
 
-This property allows you to specify whether a sound is played on capture
+This property allows you to specify whether a sound is played on capture. It is currently android only, pending [a reasonable mute implementation](http://stackoverflow.com/questions/4401232/avfoundation-how-to-turn-off-the-shutter-sound-when-capturestillimageasynchrono) in iOS.
 
 #### `iOS` `onBarCodeRead`
 
@@ -189,6 +184,10 @@ The following barcode types can be recognised:
 - `datamatrix` (when available)
 
 The barcode type is provided in the `data` object.
+
+#### `iOS` `barCodeTypes`
+
+An array of barcode types to search for. Defaults to all types listed above. No effect if `onBarCodeRead` is undefined.
 
 #### `flashMode`
 

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -70,6 +70,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
         return Collections.unmodifiableMap(new HashMap<String, Object>() {
             {
                 put("Aspect", getAspectConstants());
+                put("BarCodeType", getBarCodeConstants());
                 put("Type", getTypeConstants());
                 put("CaptureQuality", getCaptureQualityConstants());
                 put("CaptureMode", getCaptureModeConstants());
@@ -85,6 +86,14 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
                         put("stretch", RCT_CAMERA_ASPECT_STRETCH);
                         put("fit", RCT_CAMERA_ASPECT_FIT);
                         put("fill", RCT_CAMERA_ASPECT_FILL);
+                    }
+                });
+            }
+
+            private Map<String, Object> getBarCodeConstants() {
+                return Collections.unmodifiableMap(new HashMap<String, Object>() {
+                    {
+                        // @TODO add barcode types
                     }
                 });
             }
@@ -174,7 +183,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
             MediaActionSound sound = new MediaActionSound();
             sound.play(MediaActionSound.SHUTTER_CLICK);
         }
-        
+
         RCTCamera.getInstance().setCaptureQuality(options.getInt("type"), options.getString("quality"));
         camera.takePicture(null, null, new Camera.PictureCallback() {
             @Override

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -190,11 +190,11 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
             public void onPictureTaken(byte[] data, Camera camera) {
                 camera.stopPreview();
                 camera.startPreview();
-                Map<String, Object> response = new HashMap();
+                WritableMap response = new WritableNativeMap();
                 switch (options.getInt("target")) {
                     case RCT_CAMERA_CAPTURE_TARGET_MEMORY:
                         String encoded = Base64.encodeToString(data, Base64.DEFAULT);
-                        response.put("data", encoded);
+                        response.putString("data", encoded);
                         promise.resolve(response);
                         break;
                     case RCT_CAMERA_CAPTURE_TARGET_CAMERA_ROLL:
@@ -204,7 +204,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
                                 _reactContext.getContentResolver(),
                                 bitmap, options.getString("title"),
                                 options.getString("description"));
-                        response.put("path", url);
+                        response.putString("path", url);
                         promise.resolve(response);
                         break;
                     case RCT_CAMERA_CAPTURE_TARGET_DISK:
@@ -223,7 +223,8 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
                         } catch (IOException e) {
                             promise.reject("Error accessing file: " + e.getMessage());
                         }
-                        promise.resolve(Uri.fromFile(pictureFile).toString());
+                        response.putString("path", Uri.fromFile(pictureFile).toString());
+                        promise.resolve(response);
                         break;
                     case RCT_CAMERA_CAPTURE_TARGET_TEMP:
                         File tempFile = getTempMediaFile(MEDIA_TYPE_IMAGE);
@@ -242,7 +243,8 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
                         } catch (IOException e) {
                             promise.reject("Error accessing file: " + e.getMessage());
                         }
-                        promise.resolve(Uri.fromFile(tempFile).toString());
+                        response.putString("path", Uri.fromFile(tempFile).toString());
+                        promise.resolve(response);
                         break;
                 }
             }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -7,6 +7,7 @@ package com.lwansbrough.RCTCamera;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.hardware.Camera;
+import android.media.MediaActionSound;
 import android.net.Uri;
 import android.os.Environment;
 import android.provider.MediaStore;
@@ -168,6 +169,12 @@ public class RCTCameraModule extends ReactContextBaseJavaModule {
             promise.reject("No camera found.");
             return;
         }
+
+        if (options.getBoolean("playSoundOnCapture")) {
+            MediaActionSound sound = new MediaActionSound();
+            sound.play(MediaActionSound.SHUTTER_CLICK);
+        }
+        
         RCTCamera.getInstance().setCaptureQuality(options.getInt("type"), options.getString("quality"));
         camera.takePicture(null, null, new Camera.PictureCallback() {
             @Override

--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -27,35 +27,6 @@
   BOOL _previousIdleTimerDisabled;
 }
 
-- (void)setAspect:(NSInteger)aspect
-{
-  NSString *aspectString;
-  switch (aspect) {
-    default:
-    case RCTCameraAspectFill:
-      aspectString = AVLayerVideoGravityResizeAspectFill;
-      break;
-    case RCTCameraAspectFit:
-      aspectString = AVLayerVideoGravityResizeAspect;
-      break;
-    case RCTCameraAspectStretch:
-      aspectString = AVLayerVideoGravityResize;
-      break;
-  }
-  [self.manager changeAspect:aspectString];
-}
-
-- (void)setType:(NSInteger)type
-{
-  if (self.manager.session.isRunning) {
-    [self.manager changeCamera:type];
-  }
-  else {
-    self.manager.presetCamera = type;
-  }
-  [self.manager initializeCaptureSessionInput:AVMediaTypeVideo];
-}
-
 - (void)setOrientation:(NSInteger)orientation
 {
   if (orientation == RCTCameraOrientationAuto) {
@@ -66,26 +37,6 @@
     [[NSNotificationCenter defaultCenter]removeObserver:self name:UIDeviceOrientationDidChangeNotification object:nil];
     [self.manager changeOrientation:orientation];
   }
-}
-
-- (void)setMirrorImage:(BOOL)mirrorImage
-{
-  [self.manager changeMirrorImage:mirrorImage];
-}
-
-- (void)setBarCodeTypes:(NSArray *)barCodeTypes
-{
-    [self.manager changeBarCodeTypes:barCodeTypes];
-}
-
-- (void)setFlashMode:(NSInteger)flashMode
-{
-  [self.manager changeFlashMode:flashMode];
-}
-
-- (void)setTorchMode:(NSInteger)torchMode
-{
-  [self.manager changeTorchMode:torchMode];
 }
 
 - (void)setOnFocusChanged:(BOOL)enabled
@@ -106,13 +57,6 @@
 {
   if (_onZoomChanged != enabled) {
     _onZoomChanged = enabled;
-  }
-}
-
-- (void)setKeepAwake:(BOOL)enabled
-{
-  if (enabled) {
-    [UIApplication sharedApplication].idleTimerDisabled = true;
   }
 }
 

--- a/ios/RCTCameraManager.h
+++ b/ios/RCTCameraManager.h
@@ -67,13 +67,7 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 @property (nonatomic, strong) RCTCamera *camera;
 
 
-- (void)changeAspect:(NSString *)aspect;
-- (void)changeCamera:(NSInteger)camera;
 - (void)changeOrientation:(NSInteger)orientation;
-- (void)changeMirrorImage:(BOOL)mirrorImage;
-- (void)changeBarCodeTypes:(NSArray *)barCodeTypes;
-- (void)changeFlashMode:(NSInteger)flashMode;
-- (void)changeTorchMode:(NSInteger)torchMode;
 - (AVCaptureDevice *)deviceWithMediaType:(NSString *)mediaType preferringPosition:(AVCaptureDevicePosition)position;
 - (void)capture:(NSDictionary*)options resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 - (void)getFOV:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -48,26 +48,26 @@ RCT_EXPORT_VIEW_PROPERTY(barCodeTypes, NSStringArray);
                @"fill": @(RCTCameraAspectFill)
                },
            @"BarCodeType": @{
-                   @"upce": AVMetadataObjectTypeUPCECode,
-                   @"code39": AVMetadataObjectTypeCode39Code,
-                   @"code39mod43": AVMetadataObjectTypeCode39Mod43Code,
-                   @"ean13": AVMetadataObjectTypeEAN13Code,
-                   @"ean8":  AVMetadataObjectTypeEAN8Code,
-                   @"code93": AVMetadataObjectTypeCode93Code,
-                   @"code138": AVMetadataObjectTypeCode128Code,
-                   @"pdf417": AVMetadataObjectTypePDF417Code,
-                   @"qr": AVMetadataObjectTypeQRCode,
-                   @"aztec": AVMetadataObjectTypeAztecCode
-                   #ifdef AVMetadataObjectTypeInterleaved2of5Code
-                   ,@"interleaved2of5": AVMetadataObjectTypeInterleaved2of5Code
-                   # endif
-                   #ifdef AVMetadataObjectTypeITF14Code
-                   ,@"itf14": AVMetadataObjectTypeITF14Code
-                   # endif
-                   #ifdef AVMetadataObjectTypeDataMatrixCode
-                   ,@"datamatrix": AVMetadataObjectTypeDataMatrixCode
-                   # endif
-                   },
+               @"upce": AVMetadataObjectTypeUPCECode,
+               @"code39": AVMetadataObjectTypeCode39Code,
+               @"code39mod43": AVMetadataObjectTypeCode39Mod43Code,
+               @"ean13": AVMetadataObjectTypeEAN13Code,
+               @"ean8":  AVMetadataObjectTypeEAN8Code,
+               @"code93": AVMetadataObjectTypeCode93Code,
+               @"code138": AVMetadataObjectTypeCode128Code,
+               @"pdf417": AVMetadataObjectTypePDF417Code,
+               @"qr": AVMetadataObjectTypeQRCode,
+               @"aztec": AVMetadataObjectTypeAztecCode
+               #ifdef AVMetadataObjectTypeInterleaved2of5Code
+               ,@"interleaved2of5": AVMetadataObjectTypeInterleaved2of5Code
+               # endif
+               #ifdef AVMetadataObjectTypeITF14Code
+               ,@"itf14": AVMetadataObjectTypeITF14Code
+               # endif
+               #ifdef AVMetadataObjectTypeDataMatrixCode
+               ,@"datamatrix": AVMetadataObjectTypeDataMatrixCode
+               # endif
+               },
            @"Type": @{
                @"front": @(RCTCameraTypeFront),
                @"back": @(RCTCameraTypeBack)
@@ -157,7 +157,7 @@ RCT_EXPORT_METHOD(checkDeviceAuthorizationStatus:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(checkVideoAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
     __block NSString *mediaType = AVMediaTypeVideo;
-    
+
     [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
         resolve(@(granted));
     }];
@@ -669,7 +669,7 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
   AVAssetTrack* videoTrack = [[videoAsAsset tracksWithMediaType:AVMediaTypeVideo] objectAtIndex:0];
   float videoWidth;
   float videoHeight;
-  
+
   CGSize videoSize = [videoTrack naturalSize];
   CGAffineTransform txf = [videoTrack preferredTransform];
 
@@ -682,14 +682,14 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
     videoWidth = videoSize.height;
     videoHeight = videoSize.width;
   }
-  
+
   NSMutableDictionary *videoInfo = [NSMutableDictionary dictionaryWithDictionary:@{
      @"duration":[NSNumber numberWithFloat:CMTimeGetSeconds(videoAsAsset.duration)],
      @"width":[NSNumber numberWithFloat:videoWidth],
      @"height":[NSNumber numberWithFloat:videoHeight],
      @"size":[NSNumber numberWithLongLong:captureOutput.recordedFileSize],
   }];
-    
+
   if (self.videoTarget == RCTCameraCaptureTargetCameraRoll) {
     ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
     if ([library videoAtPathIsCompatibleWithSavedPhotosAlbum:outputFileURL]) {

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -23,7 +23,7 @@ RCT_EXPORT_MODULE();
 - (UIView *)view
 {
   self.session = [AVCaptureSession new];
-  
+
   self.previewLayer = [AVCaptureVideoPreviewLayer layerWithSession:self.session];
   self.previewLayer.needsDisplayOnBoundsChange = YES;
 
@@ -173,7 +173,7 @@ RCT_EXPORT_METHOD(checkDeviceAuthorizationStatus:(RCTPromiseResolveBlock)resolve
 }
 
 
-RCT_EXPORT_METHOD(checkCameraAuthorizationStatus:(RCTPromiseResolveBlock)resolve
+RCT_EXPORT_METHOD(checkVideoAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
     __block NSString *mediaType = AVMediaTypeVideo;
     
@@ -185,7 +185,7 @@ RCT_EXPORT_METHOD(checkCameraAuthorizationStatus:(RCTPromiseResolveBlock)resolve
 RCT_EXPORT_METHOD(checkAudioAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
     __block NSString *mediaType = AVMediaTypeAudio;
-    
+
     [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
         resolve(@(granted));
     }];
@@ -258,7 +258,7 @@ RCT_EXPORT_METHOD(changeOrientation:(NSInteger)orientation) {
     self.previewLayer.connection.videoOrientation = orientation;
   }
 }
-  
+
 RCT_EXPORT_METHOD(changeMirrorImage:(BOOL)mirrorImage) {
   self.mirrorImage = mirrorImage;
 }
@@ -554,18 +554,18 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
   else if (target == RCTCameraCaptureTargetDisk) {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
     NSString *documentsDirectory = [paths firstObject];
-      
+
     NSFileManager *fileManager = [NSFileManager defaultManager];
     NSString *fullPath = [[documentsDirectory stringByAppendingPathComponent:[[NSUUID UUID] UUIDString]] stringByAppendingPathExtension:@"jpg"];
-    
+
     [fileManager createFileAtPath:fullPath contents:imageData attributes:nil];
     responseString = fullPath;
   }
-    
+
   else if (target == RCTCameraCaptureTargetTemp) {
     NSString *fileName = [[NSProcessInfo processInfo] globallyUniqueString];
     NSString *fullPath = [NSString stringWithFormat:@"%@%@.jpg", NSTemporaryDirectory(), fileName];
-      
+
     [imageData writeToFile:fullPath atomically:YES];
     responseString = fullPath;
   }
@@ -711,10 +711,10 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
   else if (self.videoTarget == RCTCameraCaptureTargetTemp) {
     NSString *fileName = [[NSProcessInfo processInfo] globallyUniqueString];
     NSString *fullPath = [NSString stringWithFormat:@"%@%@.mov", NSTemporaryDirectory(), fileName];
-    
+
     NSFileManager * fileManager = [NSFileManager defaultManager];
     NSError * error = nil;
-      
+
     //moving to destination
     if (!([fileManager moveItemAtPath:[outputFileURL path] toPath:fullPath error:&error])) {
         self.videoReject(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));
@@ -734,7 +734,7 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
       if (metadata.type == barcodeType) {
         // Transform the meta-data coordinates to screen coords
         AVMetadataMachineReadableCodeObject *transformed = (AVMetadataMachineReadableCodeObject *)[_previewLayer transformedMetadataObjectForMetadataObject:metadata];
-        
+
         NSDictionary *event = @{
           @"type": metadata.type,
           @"data": metadata.stringValue,
@@ -868,7 +868,7 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
           @"zoomFactor": [NSNumber numberWithDouble:zoomFactor],
           @"velocity": [NSNumber numberWithDouble:velocity]
         };
-      
+
         [self.bridge.eventDispatcher sendInputEventWithName:@"zoomChanged" body:event];
 
         device.videoZoomFactor = zoomFactor;


### PR DESCRIPTION
Currently, there are number of props that are declared in `RCTCameraManager`, called on an `RCTCamera` instance and then immediately call back into methods on the `RCTCameraManager`. This leads to quite a confusing control flow. It also makes it more difficult to add or change existing props, because changes have to be kept in sync between three places.

This PR refactors a number of these properties to be handled entirely in the `RCTCameraManager` without crossing into `RCTCamera`. No behavior is affected, just the location that various methods are called. As a bonus, this change leads to -47 LOC.