### PR TITLE
separate React from ReactNative

### DIFF
--- a/Camera.js
+++ b/Camera.js
@@ -1,5 +1,5 @@
-import React, {
-  Component,
+import React, { Component } from 'react';
+import {
   NativeAppEventEmitter,
   NativeModules,
   Platform,


### PR DESCRIPTION
In React Native 0.25, React Native stops wrapping shared React functionality (createClass, PropTypes etc.) and expects end users to import these from the react package instead. This PR implements that behavior.
