### PR TITLE
Changed the way PropTypes is imported to fix warning in react native 0.25.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
-import React, { Component } from 'react';
+import React, { Component, PropTypes } from 'react';
 import {
   NativeAppEventEmitter,
   NativeModules,
   Platform,
-  PropTypes,
   StyleSheet,
   requireNativeComponent,
   View,


### PR DESCRIPTION
Changed the way PropTypes is imported to fix warning in react native 0.25.