### PR TITLE
always commit camera confiugration on capture session initialization

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -450,6 +450,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
     }
 
     if (captureDevice == nil) {
+      [self.session commitConfiguration];
       return;
     }
 
@@ -457,6 +458,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
 
     if (error || captureDeviceInput == nil) {
       NSLog(@"%@", error);
+      [self.session commitConfiguration];
       return;
     }
 


### PR DESCRIPTION
Hi there. 

On attempting to use this component, I have found that the app crashes when leaving the camera view.  Examination of the logs showed that the crash was because configuration changes had not been committed to the session.  This fixes the problem for me.

Thanks.
-Richard