### PR TITLE
Remove duplicate playSoundOnCapture property

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,6 @@ export default class Camera extends Component {
     options = {
       audio: props.captureAudio,
       barCodeTypes: props.barCodeTypes,
-      playSoundOnCapture: props.playSoundOnCapture,
       mode: props.captureMode,
       playSoundOnCapture: props.playSoundOnCapture,
       target: props.captureTarget,


### PR DESCRIPTION
On Android this throws a SyntaxError: Attempted to redefine property 'playSoundOnCapture'.