### PR TITLE
Add methods for retrieving the authorization status on iOS without requesting permission 

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,6 +124,9 @@ export default class Camera extends Component {
     barCodeTypes: Object.values(CameraManager.BarCodeType),
   };
 
+  static getVideoAuthorizationStatus = CameraManager.checkVideoAuthorizationStatus;
+  static getAudioAuthorizationStatus = CameraManager.checkAudioAuthorizationStatus;
+
   static checkDeviceAuthorizationStatus = CameraManager.checkDeviceAuthorizationStatus;
   static checkVideoAuthorizationStatus = CameraManager.checkVideoAuthorizationStatus;
   static checkAudioAuthorizationStatus = CameraManager.checkAudioAuthorizationStatus;

--- a/index.js
+++ b/index.js
@@ -60,7 +60,13 @@ export default class Camera extends Component {
     CaptureQuality: CameraManager.CaptureQuality,
     Orientation: CameraManager.Orientation,
     FlashMode: CameraManager.FlashMode,
-    TorchMode: CameraManager.TorchMode
+    TorchMode: CameraManager.TorchMode,
+    AuthStatus: {
+      NotDetermined: 0,
+      Restricted: 1,
+      Denied: 2,
+      Authorized: 3
+    }
   };
 
   static propTypes = {

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -136,39 +136,39 @@ RCT_CUSTOM_VIEW_PROPERTY(aspect, NSInteger, RCTCamera) {
 
 RCT_CUSTOM_VIEW_PROPERTY(type, NSInteger, RCTCamera) {
   NSInteger type = [RCTConvert NSInteger:json];
-  
+
   self.presetCamera = type;
   if (self.session.isRunning) {
     dispatch_async(self.sessionQueue, ^{
       AVCaptureDevice *currentCaptureDevice = [self.videoCaptureDeviceInput device];
       AVCaptureDevicePosition position = (AVCaptureDevicePosition)type;
       AVCaptureDevice *captureDevice = [self deviceWithMediaType:AVMediaTypeVideo preferringPosition:(AVCaptureDevicePosition)position];
-      
+
       if (captureDevice == nil) {
         return;
       }
-      
+
       self.presetCamera = type;
-      
+
       NSError *error = nil;
       AVCaptureDeviceInput *captureDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:captureDevice error:&error];
-      
+
       if (error || captureDeviceInput == nil)
       {
         NSLog(@"%@", error);
         return;
       }
-      
+
       [self.session beginConfiguration];
-      
+
       [self.session removeInput:self.videoCaptureDeviceInput];
-      
+
       if ([self.session canAddInput:captureDeviceInput])
       {
         [self.session addInput:captureDeviceInput];
-        
+
         [NSNotificationCenter.defaultCenter removeObserver:self name:AVCaptureDeviceSubjectAreaDidChangeNotification object:currentCaptureDevice];
-        
+
         [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(subjectAreaDidChange:) name:AVCaptureDeviceSubjectAreaDidChangeNotification object:captureDevice];
         self.videoCaptureDeviceInput = captureDeviceInput;
       }
@@ -176,7 +176,7 @@ RCT_CUSTOM_VIEW_PROPERTY(type, NSInteger, RCTCamera) {
       {
         [self.session addInput:self.videoCaptureDeviceInput];
       }
-      
+
       [self.session commitConfiguration];
     });
   }
@@ -187,7 +187,7 @@ RCT_CUSTOM_VIEW_PROPERTY(flashMode, NSInteger, RCTCamera) {
   AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
   NSError *error = nil;
   NSInteger *flashMode = [RCTConvert NSInteger:json];
-  
+
   if (![device hasFlash]) return;
   if (![device lockForConfiguration:&error]) {
     NSLog(@"%@", error);
@@ -214,7 +214,7 @@ RCT_CUSTOM_VIEW_PROPERTY(torchMode, NSInteger, RCTCamera) {
     NSInteger *torchMode = [RCTConvert NSInteger:json];
     AVCaptureDevice *device = [self.videoCaptureDeviceInput device];
     NSError *error = nil;
-    
+
     if (![device hasTorch]) return;
     if (![device lockForConfiguration:&error]) {
       NSLog(@"%@", error);
@@ -282,6 +282,21 @@ RCT_EXPORT_METHOD(checkDeviceAuthorizationStatus:(RCTPromiseResolveBlock)resolve
   }];
 }
 
+RCT_EXPORT_METHOD(getVideoAuthorizationStatus:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject) {
+    __block NSString *mediaType = AVMediaTypeVideo;
+
+    AVAuthorizationStatus authStatusCode = [AVCaptureDevice authorizationStatusForMediaType:mediaType];
+    resolve(@(authStatusCode));
+}
+
+RCT_EXPORT_METHOD(getAudioAuthorizationStatus:(RCTPromiseResolveBlock)resolve
+                  reject:(__unused RCTPromiseRejectBlock)reject) {
+    __block NSString *mediaType = AVMediaTypeAudio;
+
+    AVAuthorizationStatus authStatusCode = [AVCaptureDevice authorizationStatusForMediaType:mediaType];
+    resolve(@(authStatusCode));
+}
 
 RCT_EXPORT_METHOD(checkVideoAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
@@ -436,7 +451,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
         }
       }
     }
-    
+
     [self.session beginConfiguration];
 
     NSError *error = nil;


### PR DESCRIPTION
Currently, the only way to get a media type's current authorization status on iOS is to call  `check${mediaType}AuthorizationStatus`.

While it works without an issue most of the time, if the user never set the app's permissions before on that specific media type, the call will pop up a permission alert. 

If one wish to react differently if the user have or have not seen the alert (priming comes to mind), he currently has no way to do it, as the simple call to check the auth status will result in the user being prompt with the permission alert. 

To address this issues I have introduced two native methods on iOS:

```
getVideoAuthorizationStatus
getAudioAuthorizationStatus
```

Both methods return a promise that is resolved with the media type's authorization status code. 

The iOS status codes are just an integer from 0-3, so for convenience I have also added constants that hold the meaning of said status codes to the exported constant map.

The PR also removes a few trailing white spaces found in RCTCameraManager.m.
