### PR TITLE
Export constants

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,6 +219,8 @@ export default class Camera extends Component {
   }
 }
 
+export const constants = Camera.constants;
+
 const RCTCamera = requireNativeComponent('RCTCamera', Camera);
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
`Camera.constants` are now accessible with :

```js
import { constants as CameraConstants } from 'react-native-camera';
```