### PR TITLE
Move setCaptureQuality outside of capture function (iOS)

### DIFF
--- a/ios/RCTCameraManager.h
+++ b/ios/RCTCameraManager.h
@@ -9,6 +9,13 @@ typedef NS_ENUM(NSInteger, RCTCameraAspect) {
   RCTCameraAspectStretch = 2
 };
 
+typedef NS_ENUM(NSInteger, RCTCameraCaptureSessionPreset) {
+  RCTCameraCaptureSessionPresetLow = 0,
+  RCTCameraCaptureSessionPresetMedium = 1,
+  RCTCameraCaptureSessionPresetHigh = 2,
+  RCTCameraCaptureSessionPresetPhoto = 3
+};
+
 typedef NS_ENUM(NSInteger, RCTCameraCaptureMode) {
   RCTCameraCaptureModeStill = 0,
   RCTCameraCaptureModeVideo = 1


### PR DESCRIPTION
Currently sessionPreset is set every time when taking picture which causes slowdown at capture time if preset is changed. More importantly will cause blurry/dark photos when changing to 'photo' preset for a first time.

This will remove the call from capture and instead expose it same way how it is done with aspect and type.

I have been only testing this with still captures so might at least need some testing with video capture but would think that sessionPreset works similar way in that case also.

Did not find any discussion as why it was always changing it in the capture call so if this is not good solution for some reason...feedback welcome :)
