### PR TITLE
Fix initial orientation setting, refs #76

### DIFF
--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -64,7 +64,7 @@
 
 - (id)initWithManager:(RCTCameraManager*)manager bridge:(RCTBridge *)bridge
 {
-  
+
   if ((self = [super init])) {
     self.manager = manager;
     self.bridge = bridge;
@@ -183,6 +183,13 @@
 {
     if (self.manager.previewLayer.connection.isVideoOrientationSupported) {
         self.manager.previewLayer.connection.videoOrientation = orientation;
+    }
+    else {
+        // Setting videoOrientation isn't yet supported, so we have to wait until
+        // startSession has finished to set it. Put this in the queue behind.
+        dispatch_async(self.manager.sessionQueue, ^{
+            self.manager.previewLayer.connection.videoOrientation = orientation;
+        });
     }
 }
 


### PR DESCRIPTION
Fixes a bug which is described in #76 and already had been fixed in the pull request #183 . It seems that the code from the pull requests has been removed by some merge.
I just copied and adjusted the solution of the user corbt and put it in the appropriate method.

Tested with my own app on an iPad Mini Retina device with iOS 9.0.2.
