### PR TITLE
Ensure that preview orientation is correct on launch

### DIFF
--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -181,9 +181,11 @@
 
 - (void)changePreviewOrientation:(NSInteger)orientation
 {
-    if (self.manager.previewLayer.connection.isVideoOrientationSupported) {
-        self.manager.previewLayer.connection.videoOrientation = orientation;
-    }
+    dispatch_async(self.manager.sessionQueue, ^{
+        if (self.manager.previewLayer.connection.isVideoOrientationSupported) {
+            self.manager.previewLayer.connection.videoOrientation = orientation;
+        }
+    });
 }
 
 @end


### PR DESCRIPTION
Currently, with orientation="auto", the orientation is not correctly set on first render. By moving the orientation change into the sessionQueue, we ensure that the previewLayer is correctly initialised before trying to change its orientation.