### PR TITLE
Fixes issue #367

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -30,7 +30,9 @@ public class RCTCamera {
                 _cameras.put(type, camera);
                 adjustPreviewLayout(type);
             } catch (Exception e) {
-                System.console().printf("acquireCameraInstance: %s", e.getLocalizedMessage());
+                if (System.console() != null) {
+                    System.console().printf("acquireCameraInstance: %s", e.getLocalizedMessage());
+                }
             }
         }
         return _cameras.get(type);


### PR DESCRIPTION
Fixes issue #367 by checking if `System.console()` is null before attempting to use it to print. This is recommended by the Android docs.