### PR TITLE
Updates README.md: Manual Android install

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ pod 'react-native-camera', path: '../node_modules/react-native-camera'
 
 #### Android
 1. `npm install react-native-camera@https://github.com/lwansbrough/react-native-camera.git --save`
-2. Open up `android/app/src/main/java/[...]/MainActivity.java
+2. Open up `android/app/src/main/java/[...]/MainApplication.java
   - Add `import com.lwansbrough.RCTCamera.*;` to the imports at the top of the file
-  - Add `new RCTCameraPackage()` to the list returned by the `getPackages()` method
+  - Add `new RCTCameraPackage()` to the list returned by the `getPackages()` method. Add a comma to the previous item if there's already something there.
 
 3. Append the following lines to `android/settings.gradle`:
 


### PR DESCRIPTION
Changes MainActivity.java to MainApplication.java.

For people with little or no Java experience, it also ensures the list returned by getPackages() is separated by a comma.