### PR TITLE
Replace System.console with Log.e

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -6,6 +6,7 @@ package com.lwansbrough.RCTCamera;
 
 import android.hardware.Camera;
 import android.media.CamcorderProfile;
+import android.util.Log;
 
 import java.util.HashMap;
 import java.util.List;
@@ -32,9 +33,7 @@ public class RCTCamera {
                 _cameras.put(type, camera);
                 adjustPreviewLayout(type);
             } catch (Exception e) {
-                if (System.console() != null) {
-                    System.console().printf("acquireCameraInstance: %s", e.getLocalizedMessage());
-                }
+                Log.e("RCTCamera", "acquireCameraInstance failed", e);
             }
         }
         return _cameras.get(type);


### PR DESCRIPTION
System.console isn't always available (see https://github.com/lwansbrough/react-native-camera/pull/381) and isn't the best way to log errors anyway. This PR replaces it with Android's standard [`Log.e`](https://developer.android.com/reference/android/util/Log.html#e(java.lang.String, java.lang.String, java.lang.Throwable)).