### PR TITLE
Record method not documented, shouldn't be exposed

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -263,7 +263,6 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
         return null;
     }
 
-    @ReactMethod
     private void record(final ReadableMap options, final Promise promise) {
         if (mRecordingPromise != null) {
             return;


### PR DESCRIPTION
The `record` method isn't documented or available cross-platform, and does the same thing as `capture`. It shouldn't be exposed to end users.