### PR TITLE
Adjusted rotation should be that of camera, not display

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -306,7 +306,7 @@ public class RCTCamera {
         cameraInfo.rotation = rotation;
         // TODO: take in account the _orientation prop
 
-        setAdjustedDeviceOrientation(displayRotation);
+        setAdjustedDeviceOrientation(rotation);
         camera.setDisplayOrientation(displayRotation);
 
         Camera.Parameters parameters = camera.getParameters();


### PR DESCRIPTION
This minor fix causes videos recorded with the front camera in portrait orientation to have the correct orientation. Tested on Moto G and Nexus 9.