### PR TITLE
Fix setFlashMode was calling setTorchMode.

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
@@ -74,7 +74,7 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
     }
 
     public void setFlashMode(int flashMode) {
-        RCTCamera.getInstance().setTorchMode(_cameraType, flashMode);
+        RCTCamera.getInstance().setFlashMode(_cameraType, flashMode);
     }
 
     private void startPreview() {


### PR DESCRIPTION
setFlashMode was calling setTorchMode in RCTCameraViewFinder, which made it impossible to actually change the flash mode and was instead turning the torch on and off.