### PR TITLE
Mirror image for Android

### DIFF
--- a/Example/Example.js
+++ b/Example/Example.js
@@ -189,6 +189,7 @@ export default class Example extends React.Component {
           type={this.state.camera.type}
           flashMode={this.state.camera.flashMode}
           defaultTouchToFocus
+          mirrorImage={false}
         />
         <View style={[styles.overlay, styles.topOverlay]}>
           <TouchableOpacity

--- a/Example/android/settings.gradle
+++ b/Example/android/settings.gradle
@@ -2,4 +2,4 @@ rootProject.name = 'Example'
 
 include ':app'
 include ':react-native-camera'
-project(':react-native-camera').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-camera/android')
+project(':react-native-camera').projectDir = new File(rootProject.projectDir, '../../android')

--- a/README.md
+++ b/README.md
@@ -242,7 +242,6 @@ If set to `true`, the device will not sleep while the camera preview is visible.
 #### `mirrorImage`
 
 If set to `true`, the image returned will be mirrored.
-> _For Android the image will be mirrored only for **front camera**_
 
 ## Component instance methods
 

--- a/README.md
+++ b/README.md
@@ -239,9 +239,10 @@ By default, `onZoomChanged` is not defined and pinch-to-zoom is disabled.
 
 If set to `true`, the device will not sleep while the camera preview is visible. This mimics the behavior of the default camera app, which keeps the device awake while open.
 
-#### `iOS` `mirrorImage`
+#### `mirrorImage`
 
-If set to `true`, the image returned will be mirrored..
+If set to `true`, the image returned will be mirrored.
+> _For Android the image will be mirrored only for **front camera**_
 
 ## Component instance methods
 

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -5,28 +5,48 @@
 
 package com.lwansbrough.RCTCamera;
 
+import android.annotation.TargetApi;
 import android.content.ContentValues;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Matrix;
 import android.hardware.Camera;
 import android.media.CamcorderProfile;
 import android.media.MediaActionSound;
 import android.media.MediaRecorder;
 import android.media.MediaScannerConnection;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.util.Base64;
 import android.util.Log;
 import android.view.Surface;
-import com.facebook.react.bridge.*;
 
-import javax.annotation.Nullable;
-import java.io.*;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
-import java.util.Map;
 import java.util.List;
+import java.util.Map;
+
+import javax.annotation.Nullable;
 
 public class RCTCameraModule extends ReactContextBaseJavaModule implements MediaRecorder.OnInfoListener {
     private static final String TAG = "RCTCameraModule";
@@ -391,6 +411,19 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
         return byteArray;
     }
 
+    private byte[] mirrorImage(byte[] data, Camera.Size size) {
+        ByteArrayInputStream imageStream = new ByteArrayInputStream(data);
+        Bitmap photo = BitmapFactory.decodeStream(imageStream);
+
+        Matrix m = new Matrix();
+        m.preScale(-1, 1);
+        Bitmap mirroredImage = Bitmap.createBitmap(photo, 0, 0, size.width, size.height, m, false);
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        mirroredImage.compress(Bitmap.CompressFormat.JPEG, 100, stream);
+        return stream.toByteArray();
+    }
+
     @ReactMethod
     public void capture(final ReadableMap options, final Promise promise) {
         int orientation = options.hasKey("orientation") ? options.getInt("orientation") : RCTCamera.getInstance().getOrientation();
@@ -435,8 +468,14 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
 
         RCTCamera.getInstance().adjustCameraRotationToDeviceOrientation(options.getInt("type"), deviceOrientation);
         camera.takePicture(null, null, new Camera.PictureCallback() {
+            @TargetApi(Build.VERSION_CODES.KITKAT)
             @Override
             public void onPictureTaken(byte[] data, Camera camera) {
+
+                if (options.hasKey("mirrorImage") && options.getBoolean("mirrorImage")) {
+                    data = mirrorImage(data, camera.getParameters().getPreviewSize());
+                }
+
                 camera.stopPreview();
                 camera.startPreview();
                 WritableMap response = new WritableNativeMap();

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -476,13 +476,16 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
             RCTCamera.getInstance().setCaptureQuality(options.getInt("type"), options.getString("quality"));
         }
 
+        final Boolean shouldMirror = options.getInt("type") == RCT_CAMERA_TYPE_FRONT &&
+            options.hasKey("mirrorImage") && options.getBoolean("mirrorImage");
+
         RCTCamera.getInstance().adjustCameraRotationToDeviceOrientation(options.getInt("type"), deviceOrientation);
         camera.takePicture(null, null, new Camera.PictureCallback() {
             @TargetApi(Build.VERSION_CODES.KITKAT)
             @Override
             public void onPictureTaken(byte[] data, Camera camera) {
 
-                if (options.hasKey("mirrorImage") && options.getBoolean("mirrorImage")) {
+                if (shouldMirror) {
                     data = mirrorImage(data);
                 }
 

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -481,7 +481,6 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
 
         RCTCamera.getInstance().adjustCameraRotationToDeviceOrientation(options.getInt("type"), deviceOrientation);
         camera.takePicture(null, null, new Camera.PictureCallback() {
-            @TargetApi(Build.VERSION_CODES.KITKAT)
             @Override
             public void onPictureTaken(byte[] data, Camera camera) {
 

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -497,8 +497,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule implements Media
             RCTCamera.getInstance().setCaptureQuality(options.getInt("type"), options.getString("quality"));
         }
 
-        final Boolean shouldMirror = options.getInt("type") == RCT_CAMERA_TYPE_FRONT &&
-            options.hasKey("mirrorImage") && options.getBoolean("mirrorImage");
+        final Boolean shouldMirror = options.hasKey("mirrorImage") && options.getBoolean("mirrorImage");
 
         RCTCamera.getInstance().adjustCameraRotationToDeviceOrientation(options.getInt("type"), deviceOrientation);
         camera.takePicture(null, null, new Camera.PictureCallback() {

--- a/index.js
+++ b/index.js
@@ -184,6 +184,7 @@ export default class Camera extends Component {
       type: props.type,
       title: '',
       description: '',
+      mirrorImage: props.mirrorImage,
       ...options
     };
 


### PR DESCRIPTION
This PR will add Android support for `mirrorImage` option.
The image will be mirrored only if this options is set to `true` **AND** the picture was taken with the front camera.

As other properties this one can be set on the component declaration
```jsx
<Camera
  ref={cam => this.camera = cam}
  mirrorImage={true}
/>
```
or be passed as an option to the capture method
```javascript
this.camera.capture({ mirrorImage: true })
```