### PR TITLE
Added runtime check for supported bar code types

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -39,33 +39,41 @@ RCT_EXPORT_MODULE();
 
 - (NSDictionary *)constantsToExport
 {
+    
+    NSMutableDictionary * runtimeBarcodeTypes = [NSMutableDictionary dictionary];
+    [runtimeBarcodeTypes setDictionary:@{
+                                         @"upce": AVMetadataObjectTypeUPCECode,
+                                         @"code39": AVMetadataObjectTypeCode39Code,
+                                         @"code39mod43": AVMetadataObjectTypeCode39Mod43Code,
+                                         @"ean13": AVMetadataObjectTypeEAN13Code,
+                                         @"ean8":  AVMetadataObjectTypeEAN8Code,
+                                         @"code93": AVMetadataObjectTypeCode93Code,
+                                         @"code138": AVMetadataObjectTypeCode128Code,
+                                         @"pdf417": AVMetadataObjectTypePDF417Code,
+                                         @"qr": AVMetadataObjectTypeQRCode,
+                                         @"aztec": AVMetadataObjectTypeAztecCode
+                                         }];
+    
+    if (&AVMetadataObjectTypeInterleaved2of5Code != NULL) {
+        [runtimeBarcodeTypes setObject:AVMetadataObjectTypeInterleaved2of5Code forKey:@"interleaved2of5"];
+    }
+    
+    if(&AVMetadataObjectTypeITF14Code != NULL){
+        [runtimeBarcodeTypes setObject:AVMetadataObjectTypeITF14Code forKey:@"itf14"];
+    }
+    
+    if(&AVMetadataObjectTypeDataMatrixCode != NULL){
+        [runtimeBarcodeTypes setObject:AVMetadataObjectTypeDataMatrixCode forKey:@"datamatrix"];
+    }
+    
+    
   return @{
            @"Aspect": @{
                @"stretch": @(RCTCameraAspectStretch),
                @"fit": @(RCTCameraAspectFit),
                @"fill": @(RCTCameraAspectFill)
                },
-           @"BarCodeType": @{
-               @"upce": AVMetadataObjectTypeUPCECode,
-               @"code39": AVMetadataObjectTypeCode39Code,
-               @"code39mod43": AVMetadataObjectTypeCode39Mod43Code,
-               @"ean13": AVMetadataObjectTypeEAN13Code,
-               @"ean8":  AVMetadataObjectTypeEAN8Code,
-               @"code93": AVMetadataObjectTypeCode93Code,
-               @"code138": AVMetadataObjectTypeCode128Code,
-               @"pdf417": AVMetadataObjectTypePDF417Code,
-               @"qr": AVMetadataObjectTypeQRCode,
-               @"aztec": AVMetadataObjectTypeAztecCode
-               #ifdef AVMetadataObjectTypeInterleaved2of5Code
-               ,@"interleaved2of5": AVMetadataObjectTypeInterleaved2of5Code
-               # endif
-               #ifdef AVMetadataObjectTypeITF14Code
-               ,@"itf14": AVMetadataObjectTypeITF14Code
-               # endif
-               #ifdef AVMetadataObjectTypeDataMatrixCode
-               ,@"datamatrix": AVMetadataObjectTypeDataMatrixCode
-               # endif
-               },
+           @"BarCodeType": runtimeBarcodeTypes,
            @"Type": @{
                @"front": @(RCTCameraTypeFront),
                @"back": @(RCTCameraTypeBack)


### PR DESCRIPTION
During my testing, I could not can data matrices. So I set a breakpoint in `RCTCameraManager` during the metadata capture, and realized the data matrix was not being properly set.

So I changed it to do a runtime check, and now it works.
