### PR TITLE
Fix bug 357. 

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
@@ -129,6 +129,7 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
             try {
                 if (_camera != null) {
                     _camera.stopPreview();
+                    _camera.setPreviewCallback(null);
                     RCTCamera.getInstance().releaseCameraInstance(_cameraType);
                     _camera = null;
                 }


### PR DESCRIPTION
Fix for bug 357. Just sets the preview callback to null before camera release.