### PR TITLE
Default captureAudio to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The `aspect` property allows you to define how your viewfinder renders the camer
 
 #### `iOS` `captureAudio`
 
-Values: `true` (default), `false` (Boolean)
+Values: `true` (Boolean), `false` (default)
 
 *Applies to video capture mode only.* Specifies whether or not audio should be captured with the video.
 

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ export default class Camera extends Component {
     aspect: CameraManager.Aspect.fill,
     type: CameraManager.Type.back,
     orientation: CameraManager.Orientation.auto,
-    captureAudio: true,
+    captureAudio: false,
     captureMode: CameraManager.CaptureMode.still,
     captureTarget: CameraManager.CaptureTarget.cameraRoll,
     captureQuality: CameraManager.CaptureQuality.high,


### PR DESCRIPTION
Since default captureMode is a still picture, not video. 

This also works around some new iOS 10 permissions requiring notifying the user with a reason for using microphone (which is not good for the user experience if they're just taking a picture). Reference: https://github.com/lwansbrough/react-native-camera/issues/386#issuecomment-249007206

If you need video and sound, then explicitly pass it through as props in your Camera component.
