### PR TITLE
Race conditions initializing flashMode

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -31,7 +31,7 @@ public class RCTCamera {
     }
 
 
-    public Camera acquireCameraInstance(int type) {
+    public synchronized Camera acquireCameraInstance(int type) {
         if (null == _cameras.get(type) && null != _cameraTypeToIndex.get(type)) {
             try {
                 Camera camera = Camera.open(_cameraTypeToIndex.get(type));
@@ -171,7 +171,7 @@ public class RCTCamera {
     }
 
     public void setCaptureQuality(int cameraType, String captureQuality) {
-        Camera camera = _cameras.get(cameraType);
+        Camera camera = this.acquireCameraInstance(cameraType);
         if (camera == null) {
             return;
         }
@@ -197,7 +197,7 @@ public class RCTCamera {
     }
 
     public CamcorderProfile setCaptureVideoQuality(int cameraType, String captureQuality) {
-        Camera camera = _cameras.get(cameraType);
+        Camera camera = this.acquireCameraInstance(cameraType);
         if (camera == null) {
             return null;
         }
@@ -232,7 +232,7 @@ public class RCTCamera {
     }
 
     public void setTorchMode(int cameraType, int torchMode) {
-        Camera camera = _cameras.get(cameraType);
+        Camera camera = this.acquireCameraInstance(cameraType);
         if (null == camera) {
             return;
         }
@@ -256,7 +256,7 @@ public class RCTCamera {
     }
 
     public void setFlashMode(int cameraType, int flashMode) {
-        Camera camera = _cameras.get(cameraType);
+        Camera camera = this.acquireCameraInstance(cameraType);
         if (null == camera) {
             return;
         }


### PR DESCRIPTION
Fixes #433

I found race conditions initializing `flashMode` on both iOS and Android. The issue can occur when a the `type` parameter is also specified, as the camera reinitialized. The parameters get set on the old instance of the camera and never get reinitialized on the new camera instance.
