### PR TITLE
Android: Update order of RCTCamera.releaseCameraInstance

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java
@@ -48,9 +48,11 @@ public class RCTCamera {
     }
 
     public void releaseCameraInstance(int type) {
-        if (null != _cameras.get(type)) {
-            _cameras.get(type).release();
+        // Release seems async and creates race conditions. Remove from map first before releasing.
+        Camera releasingCamera = _cameras.get(type);
+        if (null != releasingCamera) {
             _cameras.remove(type);
+            releasingCamera.release();
         }
     }
 


### PR DESCRIPTION
Issue: When switching between front and back camera very quickly, looks like [adjustPreviewLayout](https://github.com/lwansbrough/react-native-camera/blob/master/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java#L372) can run on a Camera object, after [release](https://github.com/lwansbrough/react-native-camera/blob/master/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java#L53), but before the object is [removed](https://github.com/lwansbrough/react-native-camera/blob/master/android/src/main/java/com/lwansbrough/RCTCamera/RCTCamera.java#L54) from _camera map.

This just switches the order to guarantee the object is removed from the map first, before starting release.