### PR TITLE
Add video/audio authorization check for Android

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -608,6 +608,15 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
             }
         }
     }
+    
+    @ReactMethod
+    public void checkDeviceAuthorizationStatus(final Promise promise) {
+        if (!checkForPermission(Manifest.permission.CAMERA)) {
+            promise.resolve(false);
+        } else {
+            promise.resolve(checkForPermission(Manifest.permission.RECORD_AUDIO));
+        }
+    }
 
     @ReactMethod
     public void checkVideoAuthorizationStatus(final Promise promise) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -610,6 +610,25 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
     }
 
     @ReactMethod
+    public void checkVideoAuthorizationStatus(final Promise promise) {
+        promise.resolve(checkForPermission(Manifest.permission.CAMERA));
+    }
+
+    @ReactMethod
+    public void checkAudioAuthorizationStatus(final Promise promise) {
+        promise.resolve(checkForPermission(Manifest.permission.RECORD_AUDIO));
+    }
+
+    private boolean checkForPermission(String permission) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+            return true;
+        }
+
+        int p = ContextCompat.checkSelfPermission(getReactApplicationContext(), permission);
+        return p == PackageManager.PERMISSION_GRANTED;
+    }    
+
+    @ReactMethod
     public void capture(final ReadableMap options, final Promise promise) {
         int orientation = options.hasKey("orientation") ? options.getInt("orientation") : RCTCamera.getInstance().getOrientation();
         if (orientation == RCT_CAMERA_ORIENTATION_AUTO) {


### PR DESCRIPTION
This only checks for the permission and no request is made. `PermissionAndroid` in recent React Native or manually asking it from native code can still be used.