### PR TITLE
[iOS] set camera pointer to nil when stopping session in emulator

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -456,6 +456,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
 
 - (void)stopSession {
 #if TARGET_IPHONE_SIMULATOR
+  self.camera = nil;
   return;
 #endif
   dispatch_async(self.sessionQueue, ^{


### PR DESCRIPTION
We are seeing a weird behavior when using the camera component + navigation running in iOS emulator (similar to what is described in https://github.com/lwansbrough/react-native-camera/issues/512).

This PR addresses this by performing a consistent clean up even when running on the emulator 