### PR TITLE
fix for breaking iOS header change in RN 0.40.0

### DIFF
--- a/ios/RCTCamera.m
+++ b/ios/RCTCamera.m
@@ -1,9 +1,9 @@
-#import "RCTBridge.h"
+#import <React/RCTBridge.h>
 #import "RCTCamera.h"
 #import "RCTCameraManager.h"
-#import "RCTLog.h"
-#import "RCTUtils.h"
-#import "RCTEventDispatcher.h"
+#import <React/RCTLog.h>
+#import <React/RCTUtils.h>
+#import <React/RCTEventDispatcher.h>
 
 #import "UIView+React.h"
 

--- a/ios/RCTCameraManager.h
+++ b/ios/RCTCameraManager.h
@@ -1,4 +1,4 @@
-#import "RCTViewManager.h"
+#import <React/RCTViewManager.h>
 #import <AVFoundation/AVFoundation.h>
 
 @class RCTCamera;

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -1,10 +1,10 @@
 #import "RCTCameraManager.h"
 #import "RCTCamera.h"
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
-#import "RCTUtils.h"
-#import "RCTLog.h"
-#import "UIView+React.h"
+#import <React/RCTBridge.h>
+#import <React/RCTEventDispatcher.h>
+#import <React/RCTUtils.h>
+#import <React/RCTLog.h>
+#import <React/UIView+React.h>
 #import "NSMutableDictionary+ImageMetadata.m"
 #import <AssetsLibrary/ALAssetsLibrary.h>
 #import <AVFoundation/AVFoundation.h>


### PR DESCRIPTION
For the breaking "iOS native headers moved" [change in RN  0.40.0](https://github.com/facebook/react-native/releases/tag/v0.40.0).  Fixes #541.  Addresses facebook/react-native#11725.