### PR TITLE
Fixed Occasional "takePicture failed" Issue on Android

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -87,6 +87,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
     private Camera mCamera = null;
     private Promise mRecordingPromise = null;
     private ReadableMap mRecordingOptions;
+    private Boolean mSafeToCapture = true;
 
     public RCTCameraModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -657,7 +658,8 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
 
         RCTCamera.getInstance().adjustCameraRotationToDeviceOrientation(options.getInt("type"), deviceOrientation);
         camera.setPreviewCallback(null);
-        camera.takePicture(null, null, new Camera.PictureCallback() {
+
+        Camera.PictureCallback captureCallback = new Camera.PictureCallback() {
             @Override
             public void onPictureTaken(byte[] data, Camera camera) {
 
@@ -734,8 +736,19 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
                         break;
                     }
                 }
+
+                mSafeToCapture = true;
             }
-        });
+        };
+
+        if(mSafeToCapture) {
+          try {
+            camera.takePicture(null, null, captureCallback);
+            mSafeToCapture = false;
+          } catch(RuntimeException ex) {
+              Log.e(TAG, "Couldn't capture photo.", ex);
+          }
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
Fixed issue where Android camera would crash the application if the user attempted to capture too many pictures in a short timeframe.

I added a boolean value that determined whether the camera was currently capturing a picture.  If it was, then the photo would not be taken.  Once the photo taking process is finished, the boolean is reset and photos can again be taken.