### PR TITLE
Fix barcode type 'code128' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Event contains `data` (the data in the barcode) and `bounds` (the rectangle whic
 The following barcode types can be recognised:
 
 - `aztec`
-- `code138`
+- `code128`
 - `code39`
 - `code39mod43`
 - `code93`

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
@@ -187,9 +187,9 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
     /**
      * Parse barcodes as BarcodeFormat constants.
      *
-     * Supports all iOS codes except [code138, code39mod43, itf14]
+     * Supports all iOS codes except [code39mod43, itf14]
      *
-     * Additionally supports [codabar, code128, maxicode, rss14, rssexpanded, upca, upceanextension]
+     * Additionally supports [codabar, maxicode, rss14, rssexpanded, upca, upceanextension]
      */
     private BarcodeFormat parseBarCodeString(String c) {
         if ("aztec".equals(c)) {

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -57,7 +57,7 @@ RCT_EXPORT_MODULE();
                @"ean13": AVMetadataObjectTypeEAN13Code,
                @"ean8":  AVMetadataObjectTypeEAN8Code,
                @"code93": AVMetadataObjectTypeCode93Code,
-               @"code138": AVMetadataObjectTypeCode128Code,
+               @"code128": AVMetadataObjectTypeCode128Code,
                @"pdf417": AVMetadataObjectTypePDF417Code,
                @"qr": AVMetadataObjectTypeQRCode,
                @"aztec": AVMetadataObjectTypeAztecCode


### PR DESCRIPTION
Fix a typo in barcode types. The type should be `code128` instead of `code138`.