### PR TITLE
Update barcode read event listener when `onBarCodeRead` prop updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ export default class Camera extends Component {
 
   componentWillReceiveProps(newProps) {
     const { onBarCodeRead } = this.props
-    if (onBarCodeRead && !newProps.onBarCodeRead) {
+    if (onBarCodeRead !== newProps.onBarCodeRead) {
       this._addOnBarCodeReadListener(newProps)
     }
   }


### PR DESCRIPTION
Previously, if the initial `onBarCodeRead` prop is undefined, then it will never be updated even when new `onBarCodeRead` prop is provided.

After the fix, this event listener will be updated when new `onBarCodeRead` prop is received.