### PR TITLE
Fix typo in iOS automatic orientation logic

### DIFF
--- a/ios/RCTSensorOrientationChecker.m
+++ b/ios/RCTSensorOrientationChecker.m
@@ -77,7 +77,7 @@
     if(acceleration.x <= -0.75) {
         return UIInterfaceOrientationLandscapeRight;
     }
-    if(acceleration.y >= -0.75) {
+    if(acceleration.y <= -0.75) {
         return UIInterfaceOrientationPortrait;
     }
     if(acceleration.y >= 0.75) {


### PR DESCRIPTION
This typo results in all roughly face-up still pictures being interpreted as portrait shots.