### PR TITLE
iOS: minor focus and zoom changes

### DIFF
--- a/Example/Example.js
+++ b/Example/Example.js
@@ -182,6 +182,8 @@ export default class Example extends React.Component {
           captureTarget={this.state.camera.captureTarget}
           type={this.state.camera.type}
           flashMode={this.state.camera.flashMode}
+          onFocusChanged={() => {}}
+          onZoomChanged={() => {}}
           defaultTouchToFocus
           mirrorImage={false}
         />

--- a/Example/package.json
+++ b/Example/package.json
@@ -6,8 +6,8 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react": "~15.3.0",
-    "react-native": "^0.34.0",
+    "react": ">=15.4.0",
+    "react-native": ">=0.40",
     "react-native-camera": "file:../"
   }
 }

--- a/Example/package.json
+++ b/Example/package.json
@@ -6,8 +6,8 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react": ">=15.4.0",
-    "react-native": ">=0.40",
+    "react": "~15.3.0",
+    "react-native": "^0.34.0",
     "react-native-camera": "file:../"
   }
 }

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -953,16 +953,18 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
             AVCaptureDevice *device = [[self videoCaptureDeviceInput] device];
             if([device isFocusPointOfInterestSupported] &&
                [device isFocusModeSupported:AVCaptureFocusModeAutoFocus]) {
-                CGRect screenRect = [[UIScreen mainScreen] bounds];
-                double screenWidth = screenRect.size.width;
-                double screenHeight = screenRect.size.height;
-                double focus_x = atPoint.x/screenWidth;
-                double focus_y = atPoint.y/screenHeight;
+                CGRect cameraViewRect = [[self camera] bounds];
+                double cameraViewWidth = cameraViewRect.size.width;
+                double cameraViewHeight = cameraViewRect.size.height;
+                double focus_x = atPoint.x/cameraViewWidth;
+                double focus_y = atPoint.y/cameraViewHeight;
+                CGPoint cameraViewPoint = CGPointMake(focus_x, focus_y);
                 if([device lockForConfiguration:nil]) {
-                    [device setFocusPointOfInterest:CGPointMake(focus_x,focus_y)];
+                    [device setFocusPointOfInterest:cameraViewPoint];
                     [device setFocusMode:AVCaptureFocusModeAutoFocus];
-                    if ([device isExposureModeSupported:AVCaptureExposureModeAutoExpose]){
+                    if ([device isExposurePointOfInterestSupported] && [device isExposureModeSupported:AVCaptureExposureModeAutoExpose]) {
                         [device setExposureMode:AVCaptureExposureModeAutoExpose];
+                        [device setExposurePointOfInterest:cameraViewPoint];
                     }
                     [device unlockForConfiguration];
                 }


### PR DESCRIPTION
RCTCameraManager focusAtThePoint improvements
- Dynamicaly get size from bounds of camera view, instead of full screen, since
  it might not always be the case that the Camera react component is taking up
  the entire device screen.
- Also add setting exposure to the same point of interest we are focusing on.

Example
- Add onFocusChanged and onZoomChanged empty callback functions by default to
  Example app, allowing tap-to-focus and pinch-to-zoom to be readily
  experienced/experimented with.
- Updated react/react-native dependencies to match root package.json.

TODO/Other remarks
- Tap-to-focus seems to still not work perfectly... From logging, it always seems
  to get the right location in the view (meaning its getting the right location
  from the user touch and transforming it to the {0, 1} range appropriately), and
  does indeed engage the focus process, but it seems it sometimes refocuses on the
  center-ish region of what's in the camera instead of the location that was actually
  pressed. I thought this might be related to the subjectAreaDidChange getting called,
  which in turn sets the focus mode to continuous auto-focus at the view center, but
  from my experimenting, this method never actually gets called. I wasn't able to
  figure out if there's somewhere else in the library that's forcing continuous auto-focus,
  or if there's just some bug in our current focus procedure within focusAtThePoint.