### PR TITLE
Fix for rotation on front facing images with mirror set to true

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -663,14 +663,14 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
             @Override
             public void onPictureTaken(byte[] data, Camera camera) {
 
+                data = fixOrientation(data);
+
                 if (shouldMirror) {
                     data = mirrorImage(data);
                     if (data == null) {
                         promise.reject("Error mirroring image");
                     }
                 }
-
-                data = fixOrientation(data);
 
                 camera.stopPreview();
                 camera.startPreview();


### PR DESCRIPTION
This fixes a use case where mirroring is enabled and the front camera is being used. Previously the image was not rotated correctly because the mirror call strips the exif data out.

This PR moves the `fixOrientation` call above the `mirrorImage` call to ensure the exif data is available to the rotation call