### PR TITLE
let flexbox resize components

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,14 +120,13 @@ class BadInstagramCloneApp extends Component {
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1
+    flex: 1,
+    flexDirection: 'row',
   },
   preview: {
     flex: 1,
     justifyContent: 'flex-end',
-    alignItems: 'center',
-    height: Dimensions.get('window').height,
-    width: Dimensions.get('window').width
+    alignItems: 'center'
   },
   capture: {
     flex: 0,


### PR DESCRIPTION
This PR introduces a small change to fix a small styling bug in the current README.

The README currently uses `Dimensions.get('window')` to set the height/width of the camera preview. This looks great in portrait mode, but if one rotates a physical device to landscape mode, the preview only occupies half the device screen.

By allowing flexbox to resize the view, this PR makes it so that the preview occupies the full width of the device screen.