### PR TITLE
feat(ios): add support for `preview` to match viewport cropping

### DIFF
--- a/ios/RCTCameraManager.h
+++ b/ios/RCTCameraManager.h
@@ -16,7 +16,8 @@ typedef NS_ENUM(NSInteger, RCTCameraCaptureSessionPreset) {
   RCTCameraCaptureSessionPresetPhoto = 3,
   RCTCameraCaptureSessionPreset480p = 4,
   RCTCameraCaptureSessionPreset720p = 5,
-  RCTCameraCaptureSessionPreset1080p = 6
+  RCTCameraCaptureSessionPreset1080p = 6,
+  RCTCameraCaptureSessionPresetPreview = 7
 };
 
 typedef NS_ENUM(NSInteger, RCTCameraCaptureMode) {
@@ -75,6 +76,7 @@ typedef NS_ENUM(NSInteger, RCTCameraTorchMode) {
 @property (nonatomic, strong) RCTPromiseResolveBlock videoResolve;
 @property (nonatomic, strong) RCTPromiseRejectBlock videoReject;
 @property (nonatomic, strong) RCTCamera *camera;
+@property (nonatomic, assign) BOOL cropToViewport;
 
 
 - (void)changeOrientation:(NSInteger)orientation;

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -106,7 +106,8 @@ RCT_EXPORT_MODULE();
                @"720p": @(RCTCameraCaptureSessionPreset720p),
                @"AVCaptureSessionPreset1280x720": @(RCTCameraCaptureSessionPreset720p),
                @"1080p": @(RCTCameraCaptureSessionPreset1080p),
-               @"AVCaptureSessionPreset1920x1080": @(RCTCameraCaptureSessionPreset1080p)
+               @"AVCaptureSessionPreset1920x1080": @(RCTCameraCaptureSessionPreset1080p),
+               @"preview": @(RCTCameraCaptureSessionPresetPreview)
                },
            @"CaptureTarget": @{
                @"memory": @(RCTCameraCaptureTargetMemory),
@@ -140,6 +141,7 @@ RCT_EXPORT_VIEW_PROPERTY(onFocusChanged, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(onZoomChanged, BOOL);
 
 RCT_CUSTOM_VIEW_PROPERTY(captureQuality, NSInteger, RCTCamera) {
+  self.cropToViewport = false;
   NSInteger quality = [RCTConvert NSInteger:json];
   NSString *qualityString;
   switch (quality) {
@@ -164,6 +166,10 @@ RCT_CUSTOM_VIEW_PROPERTY(captureQuality, NSInteger, RCTCamera) {
       break;
     case RCTCameraCaptureSessionPreset480p:
       qualityString = AVCaptureSessionPreset640x480;
+      break;
+    case RCTCameraCaptureSessionPresetPreview:
+      qualityString = AVCaptureSessionPresetPhoto;
+      self.cropToViewport = true;
       break;
   }
 
@@ -629,6 +635,15 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
             }
           } else {
             rotatedCGImage = cgImage;
+          }
+
+          // Crop it (if capture quality is set to preview)
+          if (self.cropToViewport) {
+            CGSize viewportSize = CGSizeMake(self.previewLayer.frame.size.width, self.previewLayer.frame.size.height);
+            CGRect captureRect = CGRectMake(0, 0, CGImageGetWidth(rotatedCGImage), CGImageGetHeight(rotatedCGImage));
+            CGRect croppedSize = AVMakeRectWithAspectRatioInsideRect(viewportSize, captureRect);
+
+            rotatedCGImage = CGImageCreateWithImageInRect(rotatedCGImage, croppedSize);
           }
 
           // Erase stupid TIFF stuff


### PR DESCRIPTION
Currently `Camera.constants.CaptureQuality.preview` is only available on Android. This is an attempt to bring similar functionality to iOS when a non-standard viewport aspect ratio is being used.

The functionality differs slightly from the Android implementation. Whereas the Android implementation appears to choose the native camera preset closest to the viewport size this implementation simply crops the resulting image after capture to match the viewport aspect ratio.

Due to this difference, the capture always happens using `AVCaptureSessionPresetPhoto` which is great for photos but likely not ideal for videos.

In any case this is at least a starting point towards having similar functionality on iOS. Open for review and consideration.