### PR TITLE
make android handle metadata.location (and some other minor things...)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ class BadInstagramCloneApp extends Component {
   }
 
   takePicture() {
-    this.camera.capture()
+    const options = {};
+    //options.location = ...
+    this.camera.capture({metadata: options})
       .then((data) => console.log(data))
       .catch(err => console.error(err));
   }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -516,13 +516,15 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
     }
 
     private static Bitmap toBitmap(byte[] data) {
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
         try {
-            ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
-            Bitmap photo = BitmapFactory.decodeStream(inputStream);
-            inputStream.close();
-            return photo;
-        } catch (IOException e) {
-            throw new IllegalStateException("Will not happen", e);
+            return BitmapFactory.decodeStream(inputStream);
+        } finally {
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                Log.w("problem closing stream", e);//will not happen
+            }
         }
     }
 

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -680,7 +680,8 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
   else if (target == RCTCameraCaptureTargetCameraRoll) {
     [[[ALAssetsLibrary alloc] init] writeImageDataToSavedPhotosAlbum:imageData metadata:metadata completionBlock:^(NSURL* url, NSError* error) {
       if (error == nil) {
-        resolve(@{@"path":[url absoluteString]});
+        //path isn't really applicable here (this is an asset uri), but left it in for backward comparability
+        resolve(@{@"path":[url absoluteString], @"mediaUri":[url absoluteString]});
       }
       else {
         reject(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));


### PR DESCRIPTION
 * Android implemention now uses the metadata.location - when asking the RN CameraRoll for an image taken with this library it will now return with location information attached (same as iOS).
 * removed a little duplication in the java code, cleaned up some logging
 * added a 'mediaUri' to the return type - this is the same as the uri that the RN CameraRoll returns (applicable in certain save modes only)
 * clarified how to use metadata in docs