### PR TITLE
Android: wrap call to _camera.autoFocus into try/catch

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraViewFinder.java
@@ -371,12 +371,17 @@ class RCTCameraViewFinder extends TextureView implements TextureView.SurfaceText
 
         List<String> supportedFocusModes = params.getSupportedFocusModes();
         if (supportedFocusModes != null && supportedFocusModes.contains(Camera.Parameters.FOCUS_MODE_AUTO)) {
-            _camera.autoFocus(new Camera.AutoFocusCallback() {
-                @Override
-                public void onAutoFocus(boolean b, Camera camera) {
-                    // currently set to auto-focus on single touch
-                }
-            });
+            try {
+                _camera.autoFocus(new Camera.AutoFocusCallback() {
+                    @Override
+                    public void onAutoFocus(boolean b, Camera camera) {
+                        // currently set to auto-focus on single touch
+                    }
+                });
+            } catch (Exception e) {
+                // just print stack trace, we don't want to crash by autoFocus fails
+                e.printStackTrace();
+            }
         }
     }
 


### PR DESCRIPTION
Hello folks!
This is my first PR here, so please let me know if I made something wrong.

Related issue: https://github.com/lwansbrough/react-native-camera/issues/649

I have one device that this issue happens with me every time I try to focus while its already trying to focus, a simple solution is wrap the call to `_camera.autoFocus..` into a try/catch and just log the stack trace, since this happens in very few devices I think it's enough to prevent the crash and solve the issue, let me know your thoughts.