### PR TITLE
Fix example crashes

### DIFF
--- a/Example/android/app/src/main/java/com/example/MainApplication.java
+++ b/Example/android/app/src/main/java/com/example/MainApplication.java
@@ -17,7 +17,7 @@ public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
     @Override
-    protected boolean getUseDeveloperSupport() {
+    public boolean getUseDeveloperSupport() {
       return BuildConfig.DEBUG;
     }
 

--- a/Example/package.json
+++ b/Example/package.json
@@ -6,8 +6,8 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react": "~15.3.0",
-    "react-native": "^0.34.0",
+    "react": "^16.0.0-alpha.3",
+    "react-native": "^0.43.3",
     "react-native-camera": "file:../"
   }
 }


### PR DESCRIPTION
Update react and react-native then java compiller told me:

> {...}\react-native-camera\Example\android\app\src\main\java\com\example\MainApplication.java:20: error: getUseDeveloperSupport() in <anonymous com.example.MainApplication$1> cannot override getUseDeveloperSupport() in ReactNativeHost
    protected boolean getUseDeveloperSupport() {
                      ^
  attempting to assign weaker access privileges; was public

Fix this and voila! It`s works!