### PR TITLE
[Fix] Image orientation bug when mirroring set to true

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -561,18 +561,18 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
      * concurrently which would blow the memory (esp on smaller devices), and slow things down.
      */
     private synchronized void processImage(MutableImage mutableImage, Boolean shouldMirror, ReadableMap options, Promise promise) {
+        try {
+            mutableImage.fixOrientation();
+        } catch (MutableImage.ImageMutationFailedException e) {
+            promise.reject("Error mirroring image", e);
+        }
+        
         if (shouldMirror) {
             try {
                 mutableImage.mirrorImage();
             } catch (MutableImage.ImageMutationFailedException e) {
                 promise.reject("Error mirroring image", e);
             }
-        }
-
-        try {
-            mutableImage.fixOrientation();
-        } catch (MutableImage.ImageMutationFailedException e) {
-            promise.reject("Error mirroring image", e);
         }
 
         int jpegQualityPercent = 80;


### PR DESCRIPTION
### What was the issue?

- Taking pictures on a device that doesn't rotate the image, but rather saves rotation in EXIF, with mirroring turned on resulted in an image rotated the wrong way because the mirroring flips the image before it's rotated

### How was it fixed?

- Rotate the image before mirroring