### PR TITLE
Set more precise React/React-Native package version dependencies for Example

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -6,8 +6,8 @@
     "start": "node node_modules/react-native/local-cli/cli.js start"
   },
   "dependencies": {
-    "react": "~15.3.0",
-    "react-native": "^0.34.0",
+    "react": "~15.4.0",
+    "react-native": "~0.40.0",
     "react-native-camera": "file:../"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "description": "A Camera component for React Native. Also reads barcodes.",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "peerDependencies": {
-    "react": "~15.4.0",
-    "react-native": "~0.40.0"
+    "react": ">=15.4.0",
+    "react-native": ">=0.40"
   },
   "nativePackage": true,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "description": "A Camera component for React Native. Also reads barcodes.",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
   "peerDependencies": {
-    "react": ">=15.4.0",
-    "react-native": ">=0.40"
+    "react": "~15.4.0",
+    "react-native": "~0.40.0"
   },
   "nativePackage": true,
   "license": "MIT",


### PR DESCRIPTION
- In general, try to avoid breaking changes caused by >=
  - In particular, such a breaking change can be seen by testing the current Example
    app on Android with the existing package.json's and RN 0.43+, which causes errors
    in MainApplication public/protected method settings.