### PR TITLE
make fixOrientation an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,14 @@ If set to `true`, the device will not sleep while the camera preview is visible.
 
 If set to `true`, the image returned will be mirrored.
 
+#### `fixOrientation` (_deprecated_)
+
+If set to `true`, the image returned will be rotated to the _right way up_.  WARNING: It uses a significant amount of memory and my cause your application to crash if the device cannot provide enough RAM to perform the rotation.
+
+(_If you find that you need to use this option because your images are incorrectly oriented by default,
+could please submit a PR and include the make model of the device.  We believe that it's not 
+required functionality any more and would like to remove it._) 
+
 ## Component instance methods
 
 You can access component methods by adding a `ref` (ie. `ref="camera"`) prop to your `<Camera>` element, then you can use `this.refs.camera.capture(cb)`, etc. inside your component.

--- a/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
@@ -76,6 +76,7 @@ public class MutableImage {
         }
     }
 
+    //see http://www.impulseadventure.com/photo/exif-orientation.html
     private void rotate(int exifOrientation) throws ImageMutationFailedException {
         final Matrix bitmapMatrix = new Matrix();
         switch (exifOrientation) {

--- a/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/MutableImage.java
@@ -66,7 +66,10 @@ public class MutableImage {
                 return;
             } else if (exifIFD0Directory.containsTag(ExifIFD0Directory.TAG_ORIENTATION)) {
                 int exifOrientation = exifIFD0Directory.getInt(ExifIFD0Directory.TAG_ORIENTATION);
-                rotate(exifOrientation);
+                if(exifOrientation != 1) {
+                    rotate(exifOrientation);
+                    exifIFD0Directory.setInt(ExifIFD0Directory.TAG_ORIENTATION, 1);
+                }
             }
         } catch (ImageProcessingException | IOException | MetadataException e) {
             throw new ImageMutationFailedException("failed to fix orientation", e);
@@ -77,7 +80,7 @@ public class MutableImage {
         final Matrix bitmapMatrix = new Matrix();
         switch (exifOrientation) {
             case 1:
-                break;
+                return;//no rotation required
             case 2:
                 bitmapMatrix.postScale(-1, 1);
                 break;

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -524,8 +524,6 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
             RCTCamera.getInstance().setCaptureQuality(options.getInt("type"), options.getString("quality"));
         }
 
-        final Boolean shouldMirror = options.hasKey("mirrorImage") && options.getBoolean("mirrorImage");
-
         RCTCamera.getInstance().adjustCameraRotationToDeviceOrientation(options.getInt("type"), deviceOrientation);
         camera.setPreviewCallback(null);
 
@@ -538,7 +536,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
                 AsyncTask.execute(new Runnable() {
                     @Override
                     public void run() {
-                        processImage(new MutableImage(data), shouldMirror, options, promise);
+                        processImage(new MutableImage(data), options, promise);
                     }
                 });
 
@@ -560,7 +558,8 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
      * synchronized in order to prevent the user crashing the app by taking many photos and them all being processed
      * concurrently which would blow the memory (esp on smaller devices), and slow things down.
      */
-    private synchronized void processImage(MutableImage mutableImage, Boolean shouldMirror, ReadableMap options, Promise promise) {
+    private synchronized void processImage(MutableImage mutableImage, ReadableMap options, Promise promise) {
+        boolean shouldMirror = options.hasKey("mirrorImage") && options.getBoolean("mirrorImage");
         if (shouldMirror) {
             try {
                 mutableImage.mirrorImage();
@@ -569,10 +568,13 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
             }
         }
 
-        try {
-            mutableImage.fixOrientation();
-        } catch (MutableImage.ImageMutationFailedException e) {
-            promise.reject("Error mirroring image", e);
+        boolean shouldFixOrientation = options.hasKey("fixOrientation") && options.getBoolean("fixOrientation");
+        if(shouldFixOrientation) {
+            try {
+                mutableImage.fixOrientation();
+            } catch (MutableImage.ImageMutationFailedException e) {
+                promise.reject("Error fixing orientation image", e);
+            }
         }
 
         int jpegQualityPercent = 80;

--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ export default class Camera extends Component {
     onFocusChanged: PropTypes.func,
     onZoomChanged: PropTypes.func,
     mirrorImage: PropTypes.bool,
+    fixOrientation: PropTypes.bool,
     barCodeTypes: PropTypes.array,
     orientation: PropTypes.oneOfType([
       PropTypes.string,
@@ -120,6 +121,7 @@ export default class Camera extends Component {
     aspect: CameraManager.Aspect.fill,
     type: CameraManager.Type.back,
     orientation: CameraManager.Orientation.auto,
+    fixOrientation: false,
     captureAudio: false,
     captureMode: CameraManager.CaptureMode.still,
     captureTarget: CameraManager.CaptureTarget.cameraRoll,
@@ -219,6 +221,7 @@ export default class Camera extends Component {
       title: '',
       description: '',
       mirrorImage: props.mirrorImage,
+      fixOrientation: props.fixOrientation,
       ...options
     };
 

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -607,7 +607,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
             int metadataOrientation = [[imageMetadata objectForKey:(NSString *)kCGImagePropertyOrientation] intValue];
             
             bool rotated = false;
-            
+            //see http://www.impulseadventure.com/photo/exif-orientation.html
             if (metadataOrientation == 6) {
               rotatedCGImage = [self newCGImageRotatedByAngle:cgImage angle:270];
               rotated = true;


### PR DESCRIPTION
* added an option to fix orientation, which defaults to false
* when 'fixing' the orientation it now does nothing if the orientation in the exif data is already set to '1' (right way up)
* after fixing the orientation it writes the orientation value into the exif data (instead of deleting it in iOS, and leaving it unchanged in android)

How to test:

In summary I think that auto-fixing the orientation isn't required because the EXIF data is now preserved.  So I've added a property `fixOrientation` which defaults to false in this PR.  So if you don't set it (i.e. make no changes to your JS code) and take a photo at each of the 4 possible orientations I think they should come out correctly.