### PR TITLE
remove peerDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,6 @@
   "version": "0.8.0",
   "description": "A Camera component for React Native. Also reads barcodes.",
   "author": "Lochlan Wansbrough <lochie@live.com> (http://lwansbrough.com)",
-  "peerDependencies": {
-    "react": ">=15.4.0",
-    "react-native": ">=0.40"
-  },
   "nativePackage": true,
   "license": "MIT",
   "homepage": "https://github.com/lwansbrough/react-native-camera",


### PR DESCRIPTION
In react-native 0.44, this will cause "UNMET PEER DEPENDENCY" warning.