### PR TITLE
Update from View.propTypes to ViewPropTypes to match RN v0.44.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ import {
   StyleSheet,
   requireNativeComponent,
   View,
+  ViewPropTypes
 } from 'react-native';
 
 const CameraManager = NativeModules.CameraManager || NativeModules.CameraModule;
@@ -71,7 +72,7 @@ export default class Camera extends Component {
   };
 
   static propTypes = {
-    ...View.propTypes,
+    ...ViewPropTypes,
     aspect: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number


### PR DESCRIPTION
Update the ViewPropTypes to match the last revision of React Native V0.44.0

> View.propTypes to ViewPropTypes (53905a5) - @bvaughn
https://github.com/facebook/react-native/releases