### PR TITLE
Fix invalid reference when metadataOrientation is other than 3 or 6

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -605,7 +605,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
           } else if ([options objectForKey:@"fixOrientation"]){
             // Get metadata orientation
             int metadataOrientation = [[imageMetadata objectForKey:(NSString *)kCGImagePropertyOrientation] intValue];
-            
+
             bool rotated = false;
             //see http://www.impulseadventure.com/photo/exif-orientation.html
             if (metadataOrientation == 6) {
@@ -614,8 +614,10 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
             } else if (metadataOrientation == 3) {
               rotatedCGImage = [self newCGImageRotatedByAngle:cgImage angle:180];
               rotated = true;
+            } else {
+              rotatedCGImage = cgImage;
             }
-            
+
             if(rotated) {
               [imageMetadata setObject:[NSNumber numberWithInteger:1] forKey:(NSString *)kCGImagePropertyOrientation];
               CGImageRelease(cgImage);


### PR DESCRIPTION
The variable 
rotatedCGImage is not initialized when metadataOrientation is other than 3 or 6. Image attached.

![screen shot 2017-05-29 at 12 28 39 pm](https://cloud.githubusercontent.com/assets/620553/26537549/b542eb20-446a-11e7-84f7-d26230d4f765.png)

