### PR TITLE
Fix fixOrientation in captureStill always returns true

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -602,7 +602,7 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
           if ([options objectForKey:@"rotation"]) {
             float rotation = [[options objectForKey:@"rotation"] floatValue];
             rotatedCGImage = [self newCGImageRotatedByAngle:cgImage angle:rotation];
-          } else if ([options objectForKey:@"fixOrientation"]){
+          } else if ([[options objectForKey:@"fixOrientation"] boolValue] == YES) {
             // Get metadata orientation
             int metadataOrientation = [[imageMetadata objectForKey:(NSString *)kCGImagePropertyOrientation] intValue];
 


### PR DESCRIPTION
See this pull request: https://github.com/lwansbrough/react-native-camera/pull/728

The line https://github.com/lwansbrough/react-native-camera/blob/master/ios/RCTCameraManager.m#L605 always returns true.

The statement

```
[options objectForKey:@"fixOrientation"]
```

returns an NSCFBoolean which is always evaluated to true since the propTypes fixOrientation default is set to false in React.

![screen shot 2017-05-31 at 4 02 47 pm](https://cloud.githubusercontent.com/assets/620553/26625152/6d9c94f6-461d-11e7-85c7-d94b9ead2c75.png)
