### PR TITLE
Support React 16 PropTypes removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import {
   DeviceEventEmitter, // android
   NativeAppEventEmitter, // ios
@@ -42,7 +43,7 @@ function convertNativeProps(props) {
   if (typeof props.captureMode === 'string') {
     newProps.captureMode = Camera.constants.CaptureMode[props.captureMode];
   }
-  
+
   if (typeof props.captureTarget === 'string') {
     newProps.captureTarget = Camera.constants.CaptureTarget[props.captureTarget];
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "barcode"
   ],
   "dependencies": {
-    "opencollective": "^1.0.3"
+    "opencollective": "^1.0.3",
+    "prop-types": "^15.5.10"
   },
   "collective": {
     "type": "opencollective",


### PR DESCRIPTION
Latest React 16 alpha does not have PropTypes anymore.

https://facebook.github.io/react/blog/#migrating-from-react.proptypes
https://www.npmjs.com/package/prop-types#how-to-depend-on-this-package