### PR TITLE
Fixed README for the audio-Property for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Values: `Camera.constants.Aspect.fit` or `"fit"`, `Camera.constants.Aspect.fill`
 
 The `aspect` property allows you to define how your viewfinder renders the camera's view. For instance, if you have a square viewfinder and you want to fill the it entirely, you have two options: `"fill"`, where the aspect ratio of the camera's view is preserved by cropping the view or `"stretch"`, where the aspect ratio is skewed in order to fit the entire image inside the viewfinder. The other option is `"fit"`, which ensures the camera's entire view fits inside your viewfinder without altering the aspect ratio.
 
-#### `iOS` `captureAudio`
+#### `iOS` `audio`
 
 Values: `true` (Boolean), `false` (default)
 


### PR DESCRIPTION
Fixes #805 

Readme states that "`captureAudio`" needs to be set to true, but in native code it is called "`audio`" instead of `captureAudio`.

