### PR TITLE
Fix NullPointerException on MutableImage when taking a picture

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -598,7 +598,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
 
                 try {
                     mutableImage.writeDataToFile(cameraRollFile, options, jpegQualityPercent);
-                } catch (IOException e) {
+                } catch (IOException | NullPointerException e) {
                     promise.reject("failed to save image file", e);
                     return;
                 }


### PR DESCRIPTION
Device: 
Samsung Galaxy S7

Problem:
Happened on taking a second (not the first) picture. The second time the app was launched, it worked correctly.

Solution:
Added NullPointerException as possible exception on MutableImage usage.

Stack trace:
```
Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean android.graphics.Bitmap.compress(android.graphics.Bitmap$CompressFormat, int, java.io.OutputStream)' on a null object reference
       at com.lwansbrough.RCTCamera.MutableImage.toJpeg(MutableImage.java:213)
       at com.lwansbrough.RCTCamera.MutableImage.writeDataToFile(MutableImage.java:147)
       at com.lwansbrough.RCTCamera.RCTCameraModule.processImage(RCTCameraModule.java:600)
       at com.lwansbrough.RCTCamera.RCTCameraModule.access$200(RCTCameraModule.java:38)
       at com.lwansbrough.RCTCamera.RCTCameraModule$3$1.run(RCTCameraModule.java:539)
       at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:243)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
       at java.lang.Thread.run(Thread.java:762)
```