### PR TITLE
Remove createJSModules @override marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraPackage.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraPackage.java
@@ -17,7 +17,7 @@ public class RCTCameraPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RCTCameraModule(reactApplicationContext));
     }
 
-    // Deprecated RN 0.47
+    // Depreciated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraPackage.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraPackage.java
@@ -17,6 +17,7 @@ public class RCTCameraPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RCTCameraModule(reactApplicationContext));
     }
 
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraPackage.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraPackage.java
@@ -17,7 +17,6 @@ public class RCTCameraPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RCTCameraModule(reactApplicationContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraPackage.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraPackage.java
@@ -17,7 +17,7 @@ public class RCTCameraPackage implements ReactPackage {
         return Collections.<NativeModule>singletonList(new RCTCameraModule(reactApplicationContext));
     }
 
-    // Depreciated RN 0.47
+    // Deprecated in RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker. This is backwards compatible according to my tests in comparison to #761 