### PR TITLE
[IOS]Fix no more audio recoded after second invoke of startCapture method

### DIFF
--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -484,15 +484,6 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
 
 - (void)initializeCaptureSessionInput:(NSString *)type {
   dispatch_async(self.sessionQueue, ^{
-    if (type == AVMediaTypeAudio) {
-      for (AVCaptureDeviceInput* input in [self.session inputs]) {
-        if ([input.device hasMediaType:AVMediaTypeAudio]) {
-          // If an audio input has been configured we don't need to set it up again
-          return;
-        }
-      }
-    }
-
     [self.session beginConfiguration];
 
     NSError *error = nil;
@@ -518,6 +509,9 @@ RCT_EXPORT_METHOD(hasFlash:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRej
 
     if (type == AVMediaTypeVideo) {
       [self.session removeInput:self.videoCaptureDeviceInput];
+    }
+    else if (type == AVMediaTypeAudio && self.audioCaptureDeviceInput) {
+      [self.session removeInput:self.audioCaptureDeviceInput];
     }
 
     if ([self.session canAddInput:captureDeviceInput]) {

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -831,6 +831,13 @@ didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL
                                     if (error) {
                                       self.videoReject(RCTErrorUnspecified, nil, RCTErrorWithMessage(error.description));
                                       return;
+                                    } else if (assetURL == nil) {
+                                      // Original PR: https://github.com/lwansbrough/react-native-camera/pull/619/
+                                      // It's possible for writing to camera roll to fail,
+                                      // without receiving an error message, but assetURL will be nil
+                                      // Happens when disk is (almost) full
+                                      self.videoReject(RCTErrorUnspecified, nil, RCTErrorWithMessage(@"Not enough storage"));
+                                      return;
                                     }
                                     [videoInfo setObject:[assetURL absoluteString] forKey:@"path"];
                                     self.videoResolve(videoInfo);


### PR DESCRIPTION
## Steps to reproduce
1. After you invoke `startCapture` method for the <Camera> component, do `stopCapture` to stop video recording and get back the first video. Check that the first video has sound. (set audio=true) in the configuration of <Camera> component).
2. Now if you invoke `startCapture` again on the same component and `stopCapture` after it to get the new video.

## Expected behaviour

The second video should have audio if no setting is changed

## Actual behaviour

No sound is included in the second audio

## Environment
**Only on iOS**
react-native-camera: 10.0.0
iOS: 10
RN: 0.46.2

## Root Cause
It seems the audio input is invalidated after `stopRecording` is invoked on the `movieFileOutput` instance, also people mentioned similar issue here: https://stackoverflow.com/questions/26138207/avcapturemoviefileoutput-record-audio-only-for-the-first-video

## Fix
Re-add the audio input on every start of video recording. From the file changes you can see the author tries to *not* re-add audio input explicitly for a reason that I don't clearly see. The fix is to remove then re-add the audio input just like video input. So far in our testing no problem is raised due to this change. 