### PR TITLE
Add start/stopPreview for Camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,14 @@ Returns whether or not the camera has flash capabilities.
 
 Ends the current capture session for video captures. Only applies when the current `captureMode` is `video`.
 
+#### `stopPreview()`
+
+Stops the camera preview from running, and natively will make the current capture session pause.
+
+#### `startPreview()`
+
+Starts the camera preview again if previously stopped.
+
 ## Component static methods
 
 #### `iOS` `Camera.checkDeviceAuthorizationStatus(): Promise`

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -660,13 +660,23 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
 
     @ReactMethod
     public void stopPreview(ReadableMap options) {
-        Camera camera = RCTCamera.getInstance().acquireCameraInstance(options.getInt("type"));
+        RCTCamera instance = RCTCamera.getInstance();
+        if (instance == null) return;
+
+        Camera camera = instance.acquireCameraInstance(options.getInt("type"));
+        if (camera == null) return;
+
         camera.stopPreview();
     }
 
     @ReactMethod
     public void startPreview(ReadableMap options) {
-        Camera camera = RCTCamera.getInstance().acquireCameraInstance(options.getInt("type"));
+        RCTCamera instance = RCTCamera.getInstance();
+        if (instance == null) return;
+
+        Camera camera = instance.acquireCameraInstance(options.getInt("type"));
+        if (camera == null) return;
+
         camera.startPreview();
     }
 

--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -659,6 +659,18 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
     }
 
     @ReactMethod
+    public void stopPreview(ReadableMap options) {
+        Camera camera = RCTCamera.getInstance().acquireCameraInstance(options.getInt("type"));
+        camera.stopPreview();
+    }
+
+    @ReactMethod
+    public void startPreview(ReadableMap options) {
+        Camera camera = RCTCamera.getInstance().acquireCameraInstance(options.getInt("type"));
+        camera.startPreview();
+    }
+
+    @ReactMethod
     public void hasFlash(ReadableMap options, final Promise promise) {
         Camera camera = RCTCamera.getInstance().acquireCameraInstance(options.getInt("type"));
         if (null == camera) {

--- a/index.js
+++ b/index.js
@@ -236,6 +236,28 @@ export default class Camera extends Component {
     return CameraManager.capture(options);
   }
 
+  startPreview() {
+    if (Platform.OS === 'android') {
+      const props = convertNativeProps(this.props);
+      CameraManager.startPreview({
+        type: props.type
+      });
+    } else {
+      CameraManager.startPreview();
+    }
+  }
+
+  stopPreview() {
+    if (Platform.OS === 'android') {
+      const props = convertNativeProps(this.props);
+      CameraManager.stopPreview({
+        type: props.type
+      });
+    } else {
+      CameraManager.stopPreview();
+    }
+  }
+
   stopCapture() {
     if (this.state.isRecording) {
       this.setState({ isRecording: false });

--- a/ios/RCTCameraManager.m
+++ b/ios/RCTCameraManager.m
@@ -374,6 +374,28 @@ RCT_EXPORT_METHOD(capture:(NSDictionary *)options
   }
 }
 
+RCT_EXPORT_METHOD(stopPreview) {
+#if TARGET_IPHONE_SIMULATOR
+    return;
+#endif
+    dispatch_async(self.sessionQueue, ^{
+        if ([self.session isRunning]) {
+            [self.session stopRunning];
+        }
+    });
+}
+
+RCT_EXPORT_METHOD(startPreview) {
+#if TARGET_IPHONE_SIMULATOR
+    return;
+#endif
+    dispatch_async(self.sessionQueue, ^{
+        if (![self.session isRunning]) {
+            [self.session startRunning];
+        }
+    });
+}
+
 RCT_EXPORT_METHOD(stopCapture) {
   if (self.movieFileOutput.recording) {
     [self.movieFileOutput stopRecording];


### PR DESCRIPTION
Attempting to resolve battery drain for iOS/Android by adding functionality to start/stop preview for Camera. Might also help against slow down when Camera is running in background view.

See issue #460, #569.

The recommended approach today is to not display the view when you want the camera to be inactive. This nukes the capture session, and you have to re-display the view when you want to use camera again. This can be slow for some devices.

The idea is that instead we allow the developer to choose when to pause the current capture session with `stopPreview` and `startPreview`. Can be used in conjunction with `AppState`, and other logic like navigation events, to decide when to have the camera running.

I've only tested this on my own devices, and not 100% sure yet how much impact this will have this will have on battery/perf. Opening up this PR for discussion and feedback/testing from others.

Test app here: https://github.com/cbrevik/cameraPreviewTest