### PR TITLE
[captureWithOrientation()] Load SHUTTER_CLICK sound to reduce latency…

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -73,6 +73,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
 
     private static ReactApplicationContext _reactContext;
     private RCTSensorOrientationChecker _sensorOrientationChecker;
+    private MediaActionSound sound = new MediaActionSound();
 
     private MediaRecorder mMediaRecorder;
     private long MRStartTime;
@@ -87,6 +88,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
         _reactContext = reactContext;
         _sensorOrientationChecker = new RCTSensorOrientationChecker(_reactContext);
         _reactContext.addLifecycleEventListener(this);
+        sound.load(MediaActionSound.SHUTTER_CLICK)
     }
 
     public static ReactApplicationContext getReactContextSingleton() {
@@ -516,7 +518,6 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
         RCTCamera.getInstance().setCaptureQuality(options.getInt("type"), options.getString("quality"));
 
         if (options.hasKey("playSoundOnCapture") && options.getBoolean("playSoundOnCapture")) {
-            MediaActionSound sound = new MediaActionSound();
             sound.play(MediaActionSound.SHUTTER_CLICK);
         }
 


### PR DESCRIPTION
… while playing during capture

Found this micro improvement in the docs while I was searching for a way to fix an issue with my on-capture sound response being halved by an unapparent latency issue. Preloading the media sound and only playing it during capture solved the issue for me. 

Perhaps this initial set and load regardless of the boolean value of `playSoundOnCapture` is worth the micro bits of improvement down the road for applications that do require sound.