### PR TITLE
Missing ; on constructor

### DIFF
--- a/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
+++ b/android/src/main/java/com/lwansbrough/RCTCamera/RCTCameraModule.java
@@ -88,7 +88,7 @@ public class RCTCameraModule extends ReactContextBaseJavaModule
         _reactContext = reactContext;
         _sensorOrientationChecker = new RCTSensorOrientationChecker(_reactContext);
         _reactContext.addLifecycleEventListener(this);
-        sound.load(MediaActionSound.SHUTTER_CLICK)
+        sound.load(MediaActionSound.SHUTTER_CLICK);
     }
 
     public static ReactApplicationContext getReactContextSingleton() {


### PR DESCRIPTION
On the RCTCameraModule is missing a ';' causing a build failure.