### PR TITLE
Fix example failing with "Unable to resolve module react"

### DIFF
--- a/Example/rn-cli.config.js
+++ b/Example/rn-cli.config.js
@@ -1,0 +1,12 @@
+const path = require('path');
+
+// As the metro bundler does not support linking correctly, we add additional
+// search path queries to all modules.
+// See https://github.com/facebook/metro-bundler/issues/68
+const extraNodeModulesGetter = {
+  get: (target, name) => path.join(process.cwd(), `node_modules/${name}`),
+};
+
+module.exports = {
+  extraNodeModules: new Proxy({}, extraNodeModulesGetter),
+};


### PR DESCRIPTION
This fixes the `Unable to resolve module react` error when running the `Example` project.

Fixes https://github.com/lwansbrough/react-native-camera/issues/827, https://github.com/lwansbrough/react-native-camera/issues/597

Related to https://github.com/lwansbrough/react-native-camera/issues/820

See upstream feature/bug report at https://github.com/facebook/metro-bundler/issues/68